### PR TITLE
請求書画面で法定費用の登録と出力ができるようにする

### DIFF
--- a/Client/Components/StatutoryFeeDialog.razor
+++ b/Client/Components/StatutoryFeeDialog.razor
@@ -1,0 +1,127 @@
+@using Syncfusion.Blazor.Popups
+@using Syncfusion.Blazor.Inputs
+@using Syncfusion.Blazor.Buttons
+@using Syncfusion.Blazor.DropDowns
+@using Syncfusion.Blazor.Grids
+@using AutoDealerSphere.Shared.Models
+@using System.ComponentModel.DataAnnotations
+
+<SfDialog @ref="_dialog" Width="600px" IsModal="true" ShowCloseIcon="true" @bind-Visible="_isVisible">
+    <DialogTemplates>
+        <Header>
+            <span>法定費用選択</span>
+        </Header>
+        <Content>
+            <div class="statutory-fee-selection">
+                <h4>法定費用を選択してください</h4>
+                
+                @if (_isLoading)
+                {
+                    <div class="loading">読み込み中...</div>
+                }
+                else if (_statutoryFees == null || !_statutoryFees.Any())
+                {
+                    <div class="no-data">
+                        <p>該当する法定費用データがありません。</p>
+                        <p>車両カテゴリが正しく設定されているか確認してください。</p>
+                    </div>
+                }
+                else
+                {
+                    <div class="vehicle-info">
+                        <p><strong>車両情報:</strong> @_vehicleDisplay</p>
+                        <p><strong>車両カテゴリ:</strong> @_vehicleCategoryDisplay</p>
+                    </div>
+                    
+                    <div class="fees-grid">
+                        <SfGrid DataSource="@_statutoryFees" AllowPaging="false" AllowSorting="false">
+                            <GridColumns>
+                                <GridColumn Width="50">
+                                    <Template>
+                                        @{
+                                            var fee = (context as StatutoryFee);
+                                            <SfRadioButton Name="feeSelection" Value="@fee.Id.ToString()" @bind-Checked="_selectedFeeIdString" @onchange="@(() => OnFeeSelected(fee.Id))"></SfRadioButton>
+                                        }
+                                    </Template>
+                                </GridColumn>
+                                <GridColumn Field="@nameof(StatutoryFee.FeeType)" HeaderText="費用項目" Width="250"></GridColumn>
+                                <GridColumn Field="@nameof(StatutoryFee.Amount)" HeaderText="金額" Width="120">
+                                    <Template>
+                                        @{
+                                            var fee = (context as StatutoryFee);
+                                            <span>¥@($"{fee?.Amount:N0}")</span>
+                                        }
+                                    </Template>
+                                </GridColumn>
+                                <GridColumn Field="@nameof(StatutoryFee.IsTaxable)" HeaderText="課税" Width="80">
+                                    <Template>
+                                        @{
+                                            var fee = (context as StatutoryFee);
+                                            <span>@(fee?.IsTaxable == true ? "課税" : "非課税")</span>
+                                        }
+                                    </Template>
+                                </GridColumn>
+                            </GridColumns>
+                            <GridTemplates>
+                                <EmptyRecordTemplate>
+                                    <div class="empty-record">法定費用データがありません</div>
+                                </EmptyRecordTemplate>
+                            </GridTemplates>
+                        </SfGrid>
+                    </div>
+                }
+                
+                <div class="dialog-buttons">
+                    <SfButton @onclick="SaveSelectedFee" IsPrimary="true" Disabled="@(_selectedFeeId == 0 || _isLoading)">追加</SfButton>
+                    <SfButton @onclick="Cancel">キャンセル</SfButton>
+                </div>
+            </div>
+        </Content>
+    </DialogTemplates>
+</SfDialog>
+
+<style>
+    .statutory-fee-selection {
+        padding: 10px;
+    }
+    
+    .vehicle-info {
+        margin-bottom: 20px;
+        padding: 15px;
+        background: #f5f5f5;
+        border-radius: 5px;
+    }
+    
+    .vehicle-info p {
+        margin: 5px 0;
+    }
+    
+    .fees-grid {
+        margin-bottom: 20px;
+        max-height: 300px;
+        overflow-y: auto;
+    }
+    
+    .loading, .no-data {
+        padding: 40px;
+        text-align: center;
+        color: #666;
+    }
+    
+    .no-data p {
+        margin: 10px 0;
+    }
+    
+    .dialog-buttons {
+        display: flex;
+        justify-content: center;
+        gap: 10px;
+        margin-top: 20px;
+    }
+    
+    .empty-record {
+        padding: 20px;
+        text-align: center;
+        color: #666;
+    }
+</style>

--- a/Client/Components/StatutoryFeeDialog.razor.cs
+++ b/Client/Components/StatutoryFeeDialog.razor.cs
@@ -1,0 +1,96 @@
+using AutoDealerSphere.Shared.Models;
+using Microsoft.AspNetCore.Components;
+using Syncfusion.Blazor.Popups;
+using System.Net.Http.Json;
+
+namespace AutoDealerSphere.Client.Components
+{
+    public partial class StatutoryFeeDialog
+    {
+        [Inject]
+        private HttpClient Http { get; set; } = default!;
+
+        [Parameter]
+        public EventCallback<StatutoryFee> OnSave { get; set; }
+
+        private SfDialog? _dialog;
+        private bool _isVisible = false;
+        private bool _isLoading = false;
+        private int _invoiceId;
+        private int _vehicleId;
+        private Vehicle? _vehicle;
+        private List<StatutoryFee> _statutoryFees = new();
+        private int _selectedFeeId = 0;
+        private string _selectedFeeIdString = "";
+        private string _vehicleDisplay = "";
+        private string _vehicleCategoryDisplay = "";
+
+        public async Task Open(int invoiceId, int vehicleId)
+        {
+            _invoiceId = invoiceId;
+            _vehicleId = vehicleId;
+            _selectedFeeId = 0;
+            _selectedFeeIdString = "";
+            _isVisible = true;
+            _isLoading = true;
+            StateHasChanged();
+
+            await LoadVehicleAndFees();
+        }
+
+        private async Task LoadVehicleAndFees()
+        {
+            try
+            {
+                // 車両情報を取得
+                _vehicle = await Http.GetFromJsonAsync<Vehicle>($"api/Vehicles/{_vehicleId}");
+                
+                if (_vehicle != null)
+                {
+                    _vehicleDisplay = $"{_vehicle.VehicleName} ({_vehicle.LicensePlateNumber})";
+                    _vehicleCategoryDisplay = _vehicle.VehicleCategory?.CategoryName ?? "未設定";
+
+                    // 車両カテゴリに対応する法定費用を取得
+                    if (_vehicle.VehicleCategoryId > 0)
+                    {
+                        _statutoryFees = await Http.GetFromJsonAsync<List<StatutoryFee>>($"api/StatutoryFees/category/{_vehicle.VehicleCategoryId}") ?? new();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading vehicle and fees: {ex.Message}");
+                _statutoryFees = new();
+            }
+            finally
+            {
+                _isLoading = false;
+                StateHasChanged();
+            }
+        }
+
+        private void OnFeeSelected(int feeId)
+        {
+            _selectedFeeId = feeId;
+            _selectedFeeIdString = feeId.ToString();
+        }
+
+        private async Task SaveSelectedFee()
+        {
+            if (_selectedFeeId > 0)
+            {
+                var selectedFee = _statutoryFees.FirstOrDefault(f => f.Id == _selectedFeeId);
+                if (selectedFee != null)
+                {
+                    await OnSave.InvokeAsync(selectedFee);
+                    _isVisible = false;
+                }
+            }
+        }
+
+        private void Cancel()
+        {
+            _isVisible = false;
+        }
+    }
+}

--- a/Client/Pages/InvoiceDetailPage.razor
+++ b/Client/Pages/InvoiceDetailPage.razor
@@ -20,6 +20,7 @@
             <div class="@ExistingInvoiceButtonClass">
                 <SfButton @onclick="OpenBasicInfoDialog" CssClass="e-primary">基本編集</SfButton>
                 <SfButton @onclick="OpenDetailDialog" CssClass="e-success">明細追加</SfButton>
+                <SfButton @onclick="OpenStatutoryFeeDialog" CssClass="e-info">法定費用</SfButton>
                 <SfButton @onclick="ExportExcel">Excel出力</SfButton>
                 <SfButton @onclick="DeleteInvoice" CssClass="e-danger">削除実行</SfButton>
             </div>
@@ -159,3 +160,6 @@
 
 <!-- 明細編集ダイアログ -->
 <AutoDealerSphere.Client.Components.InvoiceDetailDialog @ref="_detailDialog" OnSave="OnDetailSaved" />
+
+<!-- 法定費用選択ダイアログ -->
+<AutoDealerSphere.Client.Components.StatutoryFeeDialog @ref="_statutoryFeeDialog" OnSave="OnStatutoryFeeSaved" />

--- a/Server/Controllers/StatutoryFeesController.cs
+++ b/Server/Controllers/StatutoryFeesController.cs
@@ -1,0 +1,75 @@
+using AutoDealerSphere.Shared.Models;
+using AutoDealerSphere.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AutoDealerSphere.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class StatutoryFeesController : ControllerBase
+    {
+        private readonly IStatutoryFeeService _statutoryFeeService;
+
+        public StatutoryFeesController(IStatutoryFeeService statutoryFeeService)
+        {
+            _statutoryFeeService = statutoryFeeService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<List<StatutoryFee>>> GetAll()
+        {
+            var fees = await _statutoryFeeService.GetAllAsync();
+            return Ok(fees);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<StatutoryFee>> GetById(int id)
+        {
+            var fee = await _statutoryFeeService.GetByIdAsync(id);
+            if (fee == null)
+                return NotFound();
+            
+            return Ok(fee);
+        }
+
+        [HttpGet("category/{categoryId}")]
+        public async Task<ActionResult<List<StatutoryFee>>> GetByCategoryId(int categoryId)
+        {
+            var fees = await _statutoryFeeService.GetByCategoryIdAsync(categoryId);
+            return Ok(fees);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<StatutoryFee>> Create(StatutoryFee statutoryFee)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var created = await _statutoryFeeService.CreateAsync(statutoryFee);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<ActionResult<StatutoryFee>> Update(int id, StatutoryFee statutoryFee)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var updated = await _statutoryFeeService.UpdateAsync(id, statutoryFee);
+            if (updated == null)
+                return NotFound();
+
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> Delete(int id)
+        {
+            var deleted = await _statutoryFeeService.DeleteAsync(id);
+            if (!deleted)
+                return NotFound();
+
+            return NoContent();
+        }
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddScoped<IVehicleImportService, VehicleImportService>();
 builder.Services.AddScoped<IPartService, PartService>();
 builder.Services.AddScoped<IInvoiceService, InvoiceService>();
 builder.Services.AddScoped<IExcelExportService, ExcelExportService>();
+builder.Services.AddScoped<IStatutoryFeeService, StatutoryFeeService>();
 
 var app = builder.Build();
 

--- a/Server/Services/IStatutoryFeeService.cs
+++ b/Server/Services/IStatutoryFeeService.cs
@@ -1,0 +1,14 @@
+using AutoDealerSphere.Shared.Models;
+
+namespace AutoDealerSphere.Server.Services
+{
+    public interface IStatutoryFeeService
+    {
+        Task<List<StatutoryFee>> GetAllAsync();
+        Task<StatutoryFee?> GetByIdAsync(int id);
+        Task<List<StatutoryFee>> GetByCategoryIdAsync(int categoryId);
+        Task<StatutoryFee> CreateAsync(StatutoryFee statutoryFee);
+        Task<StatutoryFee?> UpdateAsync(int id, StatutoryFee statutoryFee);
+        Task<bool> DeleteAsync(int id);
+    }
+}

--- a/Server/Services/StatutoryFeeService.cs
+++ b/Server/Services/StatutoryFeeService.cs
@@ -1,0 +1,88 @@
+using AutoDealerSphere.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace AutoDealerSphere.Server.Services
+{
+    public class StatutoryFeeService : IStatutoryFeeService
+    {
+        private readonly IDbContextFactory<SQLDBContext> _dbContextFactory;
+
+        public StatutoryFeeService(IDbContextFactory<SQLDBContext> dbContextFactory)
+        {
+            _dbContextFactory = dbContextFactory;
+        }
+
+        public async Task<List<StatutoryFee>> GetAllAsync()
+        {
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+            return await context.StatutoryFees
+                .Include(sf => sf.VehicleCategory)
+                .OrderBy(sf => sf.VehicleCategoryId)
+                .ThenBy(sf => sf.FeeType)
+                .ToListAsync();
+        }
+
+        public async Task<StatutoryFee?> GetByIdAsync(int id)
+        {
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+            return await context.StatutoryFees
+                .Include(sf => sf.VehicleCategory)
+                .FirstOrDefaultAsync(sf => sf.Id == id);
+        }
+
+        public async Task<List<StatutoryFee>> GetByCategoryIdAsync(int categoryId)
+        {
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+            var currentDate = DateTime.Today;
+            
+            return await context.StatutoryFees
+                .Include(sf => sf.VehicleCategory)
+                .Where(sf => sf.VehicleCategoryId == categoryId)
+                .Where(sf => sf.EffectiveFrom <= currentDate)
+                .Where(sf => sf.EffectiveTo == null || sf.EffectiveTo >= currentDate)
+                .OrderBy(sf => sf.FeeType)
+                .ToListAsync();
+        }
+
+        public async Task<StatutoryFee> CreateAsync(StatutoryFee statutoryFee)
+        {
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+            context.StatutoryFees.Add(statutoryFee);
+            await context.SaveChangesAsync();
+            return statutoryFee;
+        }
+
+        public async Task<StatutoryFee?> UpdateAsync(int id, StatutoryFee statutoryFee)
+        {
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+            var existing = await context.StatutoryFees.FindAsync(id);
+            
+            if (existing == null)
+                return null;
+
+            existing.VehicleCategoryId = statutoryFee.VehicleCategoryId;
+            existing.FeeType = statutoryFee.FeeType;
+            existing.Amount = statutoryFee.Amount;
+            existing.IsTaxable = statutoryFee.IsTaxable;
+            existing.EffectiveFrom = statutoryFee.EffectiveFrom;
+            existing.EffectiveTo = statutoryFee.EffectiveTo;
+            existing.UpdatedAt = DateTime.Now;
+
+            await context.SaveChangesAsync();
+            return existing;
+        }
+
+        public async Task<bool> DeleteAsync(int id)
+        {
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+            var statutoryFee = await context.StatutoryFees.FindAsync(id);
+            
+            if (statutoryFee == null)
+                return false;
+
+            context.StatutoryFees.Remove(statutoryFee);
+            await context.SaveChangesAsync();
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6

## 概要
請求書管理にStatutoryFeesの登録・出力機能を追加しました。

## 変更内容
- 請求書詳細画面に「法定費用」ボタンを追加
- StatutoryFeeDialogコンポーネントを作成（車両カテゴリに基づく法定費用選択）
- StatutoryFeeService、StatutoryFeesControllerを実装（API）
- Excel出力に「非課税項目」セクションを追加（左下配置）
- 法定費用を請求書明細として登録できるように実装

Co-authored-by: Kiyoshi Amano <k-amano@users.noreply.github.com>

Generated with [Claude Code](https://claude.ai/code)