### PR TITLE
fix: 法定費用選択ダイアログをチェックボックス方式に変更

### DIFF
--- a/Client/Components/StatutoryFeeDialog.razor
+++ b/Client/Components/StatutoryFeeDialog.razor
@@ -41,8 +41,7 @@
                                     <Template>
                                         @{
                                             var fee = (context as StatutoryFee);
-                                            bool isChecked = _selectedFeeIds.Contains(fee.Id);
-                                            <input type="checkbox" checked="@isChecked" @onchange="@(e => OnFeeSelectionChanged(fee.Id, (bool)e.Value))" />
+                                            <SfCheckBox @bind-Checked="@_selectedFees[fee.Id]"></SfCheckBox>
                                         }
                                     </Template>
                                 </GridColumn>
@@ -66,7 +65,7 @@
                 }
                 
                 <div class="dialog-buttons">
-                    <SfButton @onclick="SaveSelectedFees" IsPrimary="true" Disabled="@(!_selectedFeeIds.Any() || _isLoading)">保存</SfButton>
+                    <SfButton @onclick="SaveSelectedFees" IsPrimary="true" Disabled="@(_isLoading)">保存</SfButton>
                     <SfButton @onclick="Cancel">キャンセル</SfButton>
                 </div>
             </div>

--- a/Server/Controllers/VehiclesController.cs
+++ b/Server/Controllers/VehiclesController.cs
@@ -32,6 +32,7 @@ namespace AutoDealerSphere.Server.Controllers
         {
             var vehicle = await _context.Vehicles
                 .Include(v => v.Client)
+                .Include(v => v.VehicleCategory)
                 .FirstOrDefaultAsync(v => v.Id == id);
 
             if (vehicle == null)


### PR DESCRIPTION
## Summary

- 法定費用選択ダイアログでラジオボタンからチェックボックスに変更
- 既存の法定費用項目は自動的にチェック
- 「追加」ボタンを「保存」ボタンに変更し、チェックした項目を保存・チェックしていない項目を削除
- 「課税」列を削除
- 車両カテゴリ欄の既存データ反映を修正

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)