### PR TITLE
fix: InvoiceBasicInfoDialog の Invoice プロパティエラーを修正

### DIFF
--- a/Client/Pages/InvoiceList.razor
+++ b/Client/Pages/InvoiceList.razor
@@ -126,7 +126,7 @@ else
     <p class="error-message">請求書情報が見つかりません。</p>
 }
 
-<InvoiceBasicInfoDialog @ref="basicInfoDialog" Invoice="newInvoice" OnSave="OnBasicInfoSaved" />
+<InvoiceBasicInfoDialog @ref="basicInfoDialog" OnSave="OnBasicInfoSaved" />
 
 @code {
     private Invoice[]? Invoices;


### PR DESCRIPTION
## 概要

#18 の改修により発生した実行時エラーを修正しました。

## 変更内容

- `InvoiceList.razor` から不要な `Invoice="newInvoice"` プロパティを削除
- `InvoiceBasicInfoDialog` コンポーネントは `Invoice` パラメーターを持たず、代わりに `Open()` メソッドを使用する設計のため

Fixes #20

Generated with [Claude Code](https://claude.ai/code)