### PR TITLE
fix: 新規追加ダイアログで請求書を保存できない問題を修正

### DIFF
--- a/Client/Pages/InvoiceDetailPage.razor
+++ b/Client/Pages/InvoiceDetailPage.razor
@@ -13,14 +13,6 @@
 <h2>請求書詳細</h2>
 
 <div class="@MainContentClass">
-    <div class="detail-header">
-        <div class="button-group">
-            <div class="@NewInvoiceButtonClass">
-                <p>請求書の基本情報を登録してください。</p>
-                <SfButton @onclick="OpenBasicInfoDialog" CssClass="e-primary">新規登録</SfButton>
-            </div>
-        </div>
-    </div>
 
     <div class="invoice-info">
         <h3>基本情報</h3>
@@ -54,7 +46,7 @@
                 <span class="info-value">@MileageDisplay km</span>
             </div>
         </div>
-        <div class="@ExistingInvoiceButtonClass form-buttons">
+        <div class="form-buttons">
             <SfButton @onclick="OpenBasicInfoDialog" CssClass="e-primary">基本編集</SfButton>
         </div>
     </div>
@@ -152,8 +144,8 @@
 
     <div class="form-buttons">
         <SfButton @onclick="NavigateToInvoiceList">一覧へ戻る</SfButton>
-        <SfButton @onclick="ExportExcel" class="@ExistingInvoiceButtonClass">Excel出力</SfButton>
-        <SfButton @onclick="ShowDeleteConfirmation" CssClass="e-danger" class="@ExistingInvoiceButtonClass">削除実行</SfButton>
+        <SfButton @onclick="ExportExcel">Excel出力</SfButton>
+        <SfButton @onclick="ShowDeleteConfirmation" CssClass="e-danger">削除実行</SfButton>
     </div>
 </div>
 

--- a/Client/Pages/InvoiceList.razor
+++ b/Client/Pages/InvoiceList.razor
@@ -231,6 +231,20 @@ else
 
     private async Task OnBasicInfoSaved(Invoice invoice)
     {
-        NavigationManager.NavigateTo($"/invoice/detail/{invoice.Id}");
+        // 新規作成の場合、サーバーに保存
+        var response = await Http.PostAsJsonAsync("api/Invoices", invoice);
+        if (response.IsSuccessStatusCode)
+        {
+            var created = await response.Content.ReadFromJsonAsync<Invoice>();
+            if (created != null)
+            {
+                NavigationManager.NavigateTo($"/invoice/detail/{created.Id}");
+            }
+        }
+        else
+        {
+            // エラーハンドリング（実際のアプリケーションでは適切なエラー表示を実装）
+            Console.WriteLine($"Failed to save invoice: {response.StatusCode}");
+        }
     }
 }


### PR DESCRIPTION
## 概要

新規追加ダイアログで請求書を保存できない問題を修正しました。

## 変更内容

- InvoiceList.razorのOnBasicInfoSavedでサーバーへの保存処理を追加
- InvoiceDetailPageから新規追加機能を完全に削除
- invoice/detail/0 URLパターンのサポートを削除
- 保存後は正しい請求書IDで詳細画面に遷移するように修正

Closes #22

Generated with [Claude Code](https://claude.ai/code)