### PR TITLE
Fix: Ensure legal fee list is always displayed on invoice details page

### DIFF
--- a/Client/Pages/InvoiceDetailPage.razor.cs
+++ b/Client/Pages/InvoiceDetailPage.razor.cs
@@ -41,7 +41,7 @@ namespace AutoDealerSphere.Client.Pages
         protected string InvoiceNotesClass => HasNotes ? "" : "hidden";
         protected string NextInspectionRowClass => !string.IsNullOrEmpty(NextInspectionDateDisplay) ? "info-row" : "info-row hidden";
         protected string MileageRowClass => !string.IsNullOrEmpty(MileageDisplay) ? "info-row" : "info-row hidden";
-        protected string StatutoryFeesClass => StatutoryFees?.Any() == true ? "" : "hidden";
+        protected string StatutoryFeesClass => "";
         
         // 明細の分類
         protected IEnumerable<AutoDealerSphere.Shared.Models.InvoiceDetail> RegularDetails => _invoice?.InvoiceDetails?.Where(d => d.Type != "法定費用") ?? Enumerable.Empty<AutoDealerSphere.Shared.Models.InvoiceDetail>();


### PR DESCRIPTION
Fixes #28

The statutory fees section (法定費用一覧) was conditionally hidden based on whether there were any statutory fees present. Modified StatutoryFeesClass property to always return an empty string instead of 'hidden', ensuring the section is always visible as requested.

Generated with [Claude Code](https://claude.ai/code)