### PR TITLE
fix: 起動時のローディングアニメーションを円周全体に表示

### DIFF
--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -43,50 +43,74 @@
 
         .loading-spinner div:nth-child(1) {
             animation-delay: 0s;
-            top: 56px;
-            left: 99px;
+            top: 6px;
+            left: 54px;
         }
 
         .loading-spinner div:nth-child(2) {
             animation-delay: -0.1s;
-            top: 33px;
-            left: 93px;
+            top: 12px;
+            left: 76px;
         }
 
         .loading-spinner div:nth-child(3) {
             animation-delay: -0.2s;
-            top: 17px;
-            left: 78px;
+            top: 28px;
+            left: 92px;
         }
 
         .loading-spinner div:nth-child(4) {
             animation-delay: -0.3s;
-            top: 11px;
-            left: 56px;
+            top: 50px;
+            left: 98px;
         }
 
         .loading-spinner div:nth-child(5) {
             animation-delay: -0.4s;
-            top: 17px;
-            left: 33px;
+            top: 72px;
+            left: 92px;
         }
 
         .loading-spinner div:nth-child(6) {
             animation-delay: -0.5s;
-            top: 33px;
-            left: 17px;
+            top: 88px;
+            left: 76px;
         }
 
         .loading-spinner div:nth-child(7) {
             animation-delay: -0.6s;
-            top: 56px;
-            left: 11px;
+            top: 94px;
+            left: 54px;
         }
 
         .loading-spinner div:nth-child(8) {
             animation-delay: -0.7s;
-            top: 78px;
-            left: 17px;
+            top: 88px;
+            left: 32px;
+        }
+
+        .loading-spinner div:nth-child(9) {
+            animation-delay: -0.8s;
+            top: 72px;
+            left: 16px;
+        }
+
+        .loading-spinner div:nth-child(10) {
+            animation-delay: -0.9s;
+            top: 50px;
+            left: 10px;
+        }
+
+        .loading-spinner div:nth-child(11) {
+            animation-delay: -1.0s;
+            top: 28px;
+            left: 16px;
+        }
+
+        .loading-spinner div:nth-child(12) {
+            animation-delay: -1.1s;
+            top: 12px;
+            left: 32px;
         }
 
         @keyframes loading-spinner {
@@ -122,6 +146,10 @@
     <div id="app">
         <div class="loading-container">
             <div class="loading-spinner">
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
                 <div></div>
                 <div></div>
                 <div></div>


### PR DESCRIPTION
## 概要

起動時のローディングアニメーションが円周の上部しか表示されていなかった問題を修正しました。

## 変更内容

- ローディングアニメーションの円を8個から12個に増やしました
- 円周全体（360度）に均等に配置されるよう各円の座標を調整しました
- アニメーションのタイミングも12個の円に合わせて調整しました

Closes #39

Generated with [Claude Code](https://claude.ai/code)