### PR TITLE
fix: 請求書番号の不適切なバリデーション規則を修正

### DIFF
--- a/Client/Pages/InvoiceList.razor
+++ b/Client/Pages/InvoiceList.razor
@@ -221,7 +221,7 @@ else
 
     private string GenerateInvoiceNumber()
     {
-        return "自動生成";
+        return string.Empty; // 空文字列を返してサーバー側で自動生成
     }
 
     private async Task OnBasicInfoSaved(Invoice invoice)

--- a/Shared/Models/Invoice.cs
+++ b/Shared/Models/Invoice.cs
@@ -12,7 +12,6 @@ namespace AutoDealerSphere.Shared.Models
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
-        [Required(ErrorMessage = "請求書番号は必須です。")]
         [StringLength(20, ErrorMessage = "請求書番号は20文字以内で入力してください。")]
         public string InvoiceNumber { get; set; } = string.Empty;
 


### PR DESCRIPTION
## Summary
- Invoice.csのInvoiceNumberから[Required]バリデーションを削除
- 請求書番号は自動生成されるためユーザー入力バリデーションは不要
- InvoiceList.razorのGenerateInvoiceNumber()で空文字列を返すよう修正
- サーバー側で適切に請求書番号が生成される仕組みを確立

## Test plan
- [] 新規請求書作成テスト
- [] 請求書番号が実際に生成されることの確認
- [] 「請求書番号は必須です」エラーが解消されることを確認

✅ Generated with [Claude Code](https://claude.ai/code)