### PR TITLE
feat: 請求書追加ボタンの改善実装

### DIFF
--- a/Client/Components/InvoiceBasicInfoDialog.razor
+++ b/Client/Components/InvoiceBasicInfoDialog.razor
@@ -30,7 +30,8 @@
                             @bind-Value="@_model.ClientId" 
                             DataSource="@_clients"
                             Placeholder="顧客を選択"
-                            AllowFiltering="true">
+                            AllowFiltering="true"
+                            Enabled="@(!_isAddMode)">
                             <DropDownListFieldSettings Value="Id" Text="Name"></DropDownListFieldSettings>
                             <DropDownListEvents TValue="int" TItem="AutoDealerSphere.Shared.Models.Client" ValueChange="OnClientChanged"></DropDownListEvents>
                         </SfDropDownList>
@@ -129,13 +130,15 @@
     private SfDialog? _dialog;
     private bool _isVisible = false;
     private bool _isNew = false;
+    private bool _isAddMode = false; // 請求書追加モード
     private Invoice? _model;
     private List<AutoDealerSphere.Shared.Models.Client> _clients = new();
     private List<Vehicle> _vehicles = new();
 
-    public async Task Open(Invoice invoice)
+    public async Task Open(Invoice invoice, bool isAddMode = false)
     {
         _isNew = invoice.Id == 0;
+        _isAddMode = isAddMode; // 請求書追加モードを設定
         _model = new Invoice
         {
             Id = invoice.Id,

--- a/Client/Pages/InvoiceDetailPage.razor
+++ b/Client/Pages/InvoiceDetailPage.razor
@@ -145,6 +145,7 @@
     <div class="form-buttons">
         <SfButton @onclick="NavigateToInvoiceList">一覧へ戻る</SfButton>
         <SfButton @onclick="ExportExcel" CssClass="e-success">Excel出力</SfButton>
+        <SfButton @onclick="OpenAddInvoiceDialog" CssClass="e-warning">請求書追加</SfButton>
         <SfButton @onclick="ShowDeleteConfirmation" CssClass="e-danger">削除実行</SfButton>
     </div>
 </div>

--- a/Client/Pages/InvoiceList.razor
+++ b/Client/Pages/InvoiceList.razor
@@ -81,7 +81,10 @@
                 <Template>
                     @{
                         var invoice = (context as Invoice);
-                        <a href="@($"/invoice/detail/{invoice.Id}")" class="grid-link">@invoice.InvoiceNumber</a>
+                        var displayNumber = invoice.Subnumber > 1 
+                            ? $"{invoice.InvoiceNumber}-{invoice.Subnumber}" 
+                            : invoice.InvoiceNumber;
+                        <a href="@($"/invoice/detail/{invoice.Id}")" class="grid-link">@displayNumber</a>
                     }
                 </Template>
             </GridColumn>


### PR DESCRIPTION
## Summary
- 請求書詳細画面の下部（Excel出力と削除ボタンの間）に「請求書追加」ボタンを配置
- ボタンクリックで請求書基本情報編集ダイアログを表示し、顧客を事前選択・変更不可、車両選択可能に設定
- 請求書番号表示を{InvoiceNumber}-{Subnumber}形式に変更（一覧・詳細画面）
- 請求書追加時は同一請求書番号で新規請求書作成し、サーバー側で自動枝番生成

## 使用方法
1. 請求書詳細画面で「請求書追加」ボタンをクリック
2. 請求書基本情報編集ダイアログが開く
3. 顧客は事前選択済みで変更不可
4. 車両は選択可能（任意）
5. 保存すると新規請求書が作成され、その詳細画面に自動遷移
6. サーバー側で自動的に次のSubnumber（枝番）を生成

## Test plan
- [] 請求書追加ボタンのクリックテスト
- [] ダイアログの表示と顧客事前選択テスト
- [] 車両選択と新規請求書作成テスト
- [] 請求書番号表示形式の確認（一覧・詳細画面）
- [] 自動枝番生成とExcel出力テスト

✅ Generated with [Claude Code](https://claude.ai/code)