### PR TITLE
fix: 請求書基本情報編集の修正

### DIFF
--- a/Client/Components/InvoiceBasicInfoDialog.razor
+++ b/Client/Components/InvoiceBasicInfoDialog.razor
@@ -21,7 +21,7 @@
                     
                     <div class="form-row">
                         <label>請求書番号</label>
-                        <SfTextBox @bind-Value="_model.InvoiceNumber" Readonly="true"></SfTextBox>
+                        <SfTextBox Value="@GetInvoiceNumberDisplay()" Readonly="true"></SfTextBox>
                     </div>
                     
                     <div class="form-row">
@@ -45,7 +45,7 @@
                             DataSource="@_vehicles"
                             Placeholder="車両を選択（任意）"
                             Enabled="@(_vehicles != null && _vehicles.Any())">
-                            <DropDownListFieldSettings Value="Id" Text="VehicleName"></DropDownListFieldSettings>
+                            <DropDownListFieldSettings Value="Id" Text="LicensePlateNumber"></DropDownListFieldSettings>
                         </SfDropDownList>
                         <ValidationMessage For="@(() => _model.VehicleId)" />
                     </div>
@@ -143,6 +143,7 @@
         {
             Id = invoice.Id,
             InvoiceNumber = invoice.InvoiceNumber,
+            Subnumber = invoice.Subnumber,
             ClientId = invoice.ClientId,
             VehicleId = invoice.VehicleId,
             InvoiceDate = invoice.InvoiceDate,
@@ -195,5 +196,14 @@
     private void Cancel()
     {
         _isVisible = false;
+    }
+    
+    private string GetInvoiceNumberDisplay()
+    {
+        if (_model == null) return string.Empty;
+        if (string.IsNullOrEmpty(_model.InvoiceNumber)) return "自動生成";
+        if (_model.Subnumber > 1)
+            return $"{_model.InvoiceNumber}-{_model.Subnumber}";
+        return _model.InvoiceNumber;
     }
 }

--- a/Client/Pages/InvoiceDetailPage.razor.cs
+++ b/Client/Pages/InvoiceDetailPage.razor.cs
@@ -133,8 +133,22 @@ namespace AutoDealerSphere.Client.Pages
             }
             else
             {
-                // 更新モード
-                var response = await Http.PutAsJsonAsync($"api/Invoices/{InvoiceId}", invoice);
+                // 更新モード - 必要なプロパティのみ更新
+                var updateData = new
+                {
+                    invoice.Id,
+                    invoice.InvoiceNumber,
+                    invoice.Subnumber,
+                    invoice.ClientId,
+                    invoice.VehicleId,
+                    invoice.InvoiceDate,
+                    invoice.WorkCompletedDate,
+                    invoice.NextInspectionDate,
+                    invoice.Mileage,
+                    invoice.Notes,
+                    invoice.TaxRate
+                };
+                var response = await Http.PutAsJsonAsync($"api/Invoices/{InvoiceId}", updateData);
                 if (response.IsSuccessStatusCode)
                 {
                     await LoadInvoice();


### PR DESCRIPTION
## Summary
- 請求書番号表示を{InvoiceNumber}-{Subnumber}形式に修正
- 車両選択プルダウンの表示をLicensePlateNumberに変更
- 車両変更が保存されない問題を修正
- SubnumberプロパティがDialogで正しく複製されるよう修正

## 修正内容

**1. 請求書番号表示の修正**
- InvoiceBasicInfoDialog.razor:24 - GetInvoiceNumberDisplay()メソッドを追加
- Subnumber > 1の場合は{InvoiceNumber}-{Subnumber}形式で表示
- 新規作成時は「自動生成」と表示

**2. 車両選択プルダウンの修正**
- InvoiceBasicInfoDialog.razor:48 - Text="LicensePlateNumber"に変更
- 車両一覧でナンバープレート番号が表示されるよう変更

**3. 車両変更保存問題の修正**
- InvoiceDetailPage.razor.cs:136-156 - 更新時のデータ送信を匿名オブジェクトに変更
- VehicleIdを含む必要なプロパティを明示的に指定し、車両変更が確実に保存されるよう修正

**4. Subnumberプロパティの複製修正**
- InvoiceBasicInfoDialog.razor:153 - Dialogオープン時にSubnumberプロパティも正しく複製

## Test plan
- [] 請求書基本情報編集で請求書番号が{InvoiceNumber}-{Subnumber}形式で表示されることの確認
- [] 車両選択プルダウンでナンバープレート番号が表示されることの確認
- [] 車両変更が正常に保存されることの確認

✅ Generated with [Claude Code](https://claude.ai/code)