### PR TITLE
fix: Excel出力の明細データ重複問題とシート並び順問題を修正

### DIFF
--- a/Server/Services/ExcelExportService.cs
+++ b/Server/Services/ExcelExportService.cs
@@ -228,8 +228,8 @@ namespace AutoDealerSphere.Server.Services
                     }
                     else
                     {
-                        // 2枚目以降は最初のシートをコピー
-                        worksheet = workbook.Worksheets.AddCopyAfter(workbook.Worksheets[0], workbook.Worksheets[0]);
+                        // 2枚目以降は最後のシートの後にコピー
+                        worksheet = workbook.Worksheets.AddCopyAfter(workbook.Worksheets[0], workbook.Worksheets[workbook.Worksheets.Count - 1]);
                     }
 
                     // シート名を{InvoiceNumber}-{Subnumber}形式に設定
@@ -424,7 +424,7 @@ namespace AutoDealerSphere.Server.Services
         {
             int row = 20;  // 18から2行下に移動
             var taxableDetails = invoice.InvoiceDetails
-                .Where(d => d.Type != "法定費用")
+                .Where(d => d.InvoiceId == invoice.Id && d.Type != "法定費用")
                 .OrderBy(d => d.DisplayOrder);
 
             foreach (var detail in taxableDetails)
@@ -446,7 +446,7 @@ namespace AutoDealerSphere.Server.Services
         {
             int row = 42;  // 41から1行下に移動
             var nonTaxableItems = invoice.InvoiceDetails
-                .Where(d => d.Type == "法定費用")
+                .Where(d => d.InvoiceId == invoice.Id && d.Type == "法定費用")
                 .OrderBy(d => d.DisplayOrder);
 
             foreach (var item in nonTaxableItems)
@@ -462,10 +462,10 @@ namespace AutoDealerSphere.Server.Services
         // 合計を設定
         private void PopulateTotals(IWorksheet worksheet, Invoice invoice)
         {
-            var taxableDetails = invoice.InvoiceDetails.Where(d => d.Type != "法定費用");
+            var taxableDetails = invoice.InvoiceDetails.Where(d => d.InvoiceId == invoice.Id && d.Type != "法定費用");
             var partsSubTotal = taxableDetails.Sum(d => d.Quantity * d.UnitPrice);
             var laborSubTotal = taxableDetails.Sum(d => d.LaborCost);
-            var nonTaxableTotal = invoice.InvoiceDetails.Where(d => d.Type == "法定費用").Sum(d => d.UnitPrice);
+            var nonTaxableTotal = invoice.InvoiceDetails.Where(d => d.InvoiceId == invoice.Id && d.Type == "法定費用").Sum(d => d.UnitPrice);
             
             decimal taxableTotal = partsSubTotal + laborSubTotal;
             int tax = (int)(taxableTotal * 0.1m);


### PR DESCRIPTION
## Summary
- 明細データフィルタリングの修正: 各シートで該当するInvoiceIdの明細のみを表示するようにフィルタリングを追加
- Excelシート作成順序の修正: 2枚目以降のシートを最後のシートの後に追加するよう変更し、Subnumber順の正しい並びを実現
- PopulateInvoiceDetails, PopulateNonTaxableItems, PopulateTotalsメソッドでInvoiceIdによる適切なフィルタリングを実装

## 根本原因
**1. 明細データ重複問題**: 各シートで同じ`invoice`オブジェクトの`InvoiceDetails`を使用していたため、Subnumber=1の明細がSubnumber=2,3のシートにも表示されていた

**2. シート並び順問題**: `AddCopyAfter`で常に最初のシート（index=0）の後に追加していたため、シート順序が1-3-2となっていた

## Test plan
- [ ] 複数の請求書（異なるSubnumber）を作成してExcel出力テスト
- [ ] 各シートに適切な明細データのみが表示されることを確認
- [ ] シートの並び順がSubnumber順であることを確認
- [ ] Excel出力機能の全体的な動作テスト

✅ Generated with [Claude Code](https://claude.ai/code)