### PR TITLE
Fix Excel export invoice details data isolation issue

### DIFF
--- a/Server/Services/IInvoiceService.cs
+++ b/Server/Services/IInvoiceService.cs
@@ -12,6 +12,7 @@ namespace AutoDealerSphere.Server.Services
         Task<string> GenerateInvoiceNumberAsync(int clientId);
         Task<(string invoiceNumber, int subnumber)> GenerateInvoiceNumberAndSubnumberAsync(int clientId, string? existingInvoiceNumber = null);
         Task<byte[]> ExportToExcelAsync(int invoiceId);
+        Task<List<Invoice>> GetInvoicesByInvoiceNumberAsync(string invoiceNumber);
         
         // 明細CRUD操作
         Task<InvoiceDetail> CreateInvoiceDetailAsync(int invoiceId, InvoiceDetail detail);


### PR DESCRIPTION
Fixes #74

Root cause: GetAllInvoicesAsync was loading all InvoiceDetails for all invoices causing data mixing
Solution: 
- Add GetInvoicesByInvoiceNumberAsync that loads each invoice with only its own InvoiceDetails  
- Remove problematic GetRelatedInvoicesAsync method
- Remove unnecessary InvoiceId filtering since each Invoice now contains only its own details
- Each sheet now displays correct InvoiceDetails for its specific Subnumber

Generated with [Claude Code](https://claude.ai/code)