### PR TITLE
fix: メニューアイコンを存在するクラス名に修正

### DIFF
--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -41,13 +41,13 @@
         {
             Text = "車両管理",
             Url = "/vehiclelist",
-            IconCss = "e-icons e-list"
+            IconCss = "e-icons e-grid-view"
         },
         new AutoDealerSphere.Client.Shared.MenuItems()
         {
             Text = "車両データインポート",
             Url = "/vehicle-import",
-            IconCss = "e-icons e-upload"
+            IconCss = "e-icons e-arrow-up"
         },
         new AutoDealerSphere.Client.Shared.MenuItems()
         {
@@ -59,7 +59,7 @@
         {
             Text = "請求書管理",
             Url = "/invoicelist",
-            IconCss = "e-icons e-file"
+            IconCss = "e-icons e-file-document"
         },
         new AutoDealerSphere.Client.Shared.MenuItems()
         {
@@ -71,13 +71,13 @@
         {
             Text = "発行者情報管理",
             Url = "/issuerinfo",
-            IconCss = "e-icons e-briefcase"
+            IconCss = "e-icons e-circle-info"
         },
         new AutoDealerSphere.Client.Shared.MenuItems()
         {
             Text = "ログアウト",
             Url = "/",
-            IconCss = "e-icons e-sign-out"
+            IconCss = "e-icons e-close"
         }
     };
 }


### PR DESCRIPTION
Syncfusionのメニューアイコンが表示されない問題を修正しました。

## 変更内容
- e-list → e-grid-view (車両管理)
- e-upload → e-arrow-up (車両データインポート)
- e-file → e-file-document (請求書管理)
- e-briefcase → e-circle-info (発行者情報管理)
- e-sign-out → e-close (ログアウト)

Fixes #77

🤖 Generated with [Claude Code](https://claude.ai/code)