### PR TITLE
feat: 請求書詳細ページにナビゲーションボタンを追加

### DIFF
--- a/Client/Pages/InvoiceDetailPage.razor
+++ b/Client/Pages/InvoiceDetailPage.razor
@@ -144,7 +144,18 @@
 
     <div class="form-buttons">
         <SfButton @onclick="NavigateToInvoiceList">一覧へ戻る</SfButton>
-        <SfButton @onclick="ExportExcel" CssClass="e-success">Excel出力</SfButton>
+        @if (HasPreviousInvoice)
+        {
+            <SfButton @onclick="NavigateToPreviousInvoice" CssClass="e-info">前ページ</SfButton>
+        }
+        @if (HasNextInvoice)
+        {
+            <SfButton @onclick="NavigateToNextInvoice" CssClass="e-info">次ページ</SfButton>
+        }
+        @if (IsFirstInvoice)
+        {
+            <SfButton @onclick="ExportExcel" CssClass="e-success">Excel出力</SfButton>
+        }
         <SfButton @onclick="OpenAddInvoiceDialog" CssClass="e-warning">請求書追加</SfButton>
         <SfButton @onclick="ShowDeleteConfirmation" CssClass="e-danger">削除実行</SfButton>
     </div>

--- a/Server/Controllers/InvoicesController.cs
+++ b/Server/Controllers/InvoicesController.cs
@@ -87,6 +87,13 @@ namespace AutoDealerSphere.Server.Controllers
             return NoContent();
         }
 
+        [HttpGet("by-invoice-number/{invoiceNumber}")]
+        public async Task<ActionResult<Dictionary<int, Invoice>>> GetInvoicesByInvoiceNumber(string invoiceNumber)
+        {
+            var invoices = await _invoiceService.GetInvoicesByInvoiceNumberAsync(invoiceNumber);
+            return Ok(invoices);
+        }
+
         [HttpGet("{id}/export")]
         public async Task<IActionResult> ExportToExcel(int id)
         {


### PR DESCRIPTION
Fixes #79

## 概要
請求書詳細ページにナビゲーションボタンを追加しました。

## 変更内容
- Excel出力ボタンをSubnumber=1の場合のみ表示
- 前ページ・次ページボタンを一覧へ戻るボタンの右側に配置
- 最初のページは次ページボタンのみ、最後のページは前ページボタンのみ表示

## 技術的変更
- サーバー側にInvoiceNumber別取得APIエンドポイントを追加
- クライアント側に関連請求書管理とナビゲーション機能を実装

Generated with [Claude Code](https://claude.ai/code)