### PR TITLE
fix: 請求書詳細画面のナビゲーションボタンの動作を修正

### DIFF
--- a/Client/Pages/InvoiceDetailPage.razor.cs
+++ b/Client/Pages/InvoiceDetailPage.razor.cs
@@ -55,6 +55,12 @@ namespace AutoDealerSphere.Client.Pages
             await LoadRelatedInvoices();
         }
 
+        protected override async Task OnParametersSetAsync()
+        {
+            await LoadInvoice();
+            await LoadRelatedInvoices();
+        }
+
         private async Task LoadInvoice()
         {
             if (InvoiceId == 0)


### PR DESCRIPTION
Fixes #79

## 概要
請求書詳細ページの前ページ・次ページボタンのナビゲーション動作を修正しました。

## 問題の原因
BlazorコンポーネントではURLパラメータが変更されてもOnInitializedAsyncは再実行されないため、ナビゲーション後にデータが更新されていませんでした。

## 修正内容
- OnParametersSetAsyncメソッドを追加
- パラメータ変更時に請求書データと関連請求書データを再読み込み

## テスト
ビルドも正常に完了し、前ページ・次ページボタンが正しく動作するようになりました。

✅ Generated with [Claude Code](https://claude.ai/code)