### PR TITLE
fix: 請求書ダイアログのスタイル問題を修正

### DIFF
--- a/Client/Components/InvoiceBasicInfoDialog.razor
+++ b/Client/Components/InvoiceBasicInfoDialog.razor
@@ -5,7 +5,6 @@
 @using Syncfusion.Blazor.Buttons
 @using AutoDealerSphere.Shared.Models
 @using System.ComponentModel.DataAnnotations
-@inject HttpClient Http
 
 <SfDialog @ref="_dialog" Width="600px" IsModal="true" ShowCloseIcon="true" @bind-Visible="_isVisible">
     <DialogTemplates>
@@ -15,7 +14,7 @@
         <Content>
             @if (_model != null)
             {
-                <div class="@(!_isNew ? "edit-mode" : "")">
+                <div class="invoice-basic-info-dialog">
                     <EditForm Model="@_model" OnValidSubmit="OnValidSubmit">
                         <DataAnnotationsValidator />
                         <ValidationSummary />
@@ -88,130 +87,3 @@
         </Content>
     </DialogTemplates>
 </SfDialog>
-
-<style>
-    .form-row {
-        display: flex;
-        align-items: center;
-        margin-bottom: 15px;
-        gap: 10px;
-    }
-
-    /* 新規作成モード */
-    .form-row label {
-        width: 120px;
-        color: #333;
-    }
-
-    /* 編集モード - ラベル幅を広げる */
-    .edit-mode .form-row label {
-        width: 150px;
-    }
-
-    .form-row .e-input-group,
-    .form-row .e-ddl,
-    .form-row .e-date-wrapper {
-        flex: 1;
-    }
-
-    .dialog-buttons {
-        display: flex;
-        justify-content: center;
-        gap: 10px;
-        margin-top: 20px;
-    }
-
-    .required::after {
-        content: "必須";
-        color: #ffffff;
-        background: #cc0000;
-        font-size: 0.8em;
-        padding: 0.3em;
-        border-radius: 0.5em;
-        margin-left: 0.3em;
-    }
-</style>
-
-@code {
-    [Parameter] public EventCallback<Invoice> OnSave { get; set; }
-
-    private SfDialog? _dialog;
-    private bool _isVisible = false;
-    private bool _isNew = false;
-    private bool _isAddMode = false; // 請求書追加モード
-    private Invoice? _model;
-    private List<AutoDealerSphere.Shared.Models.Client> _clients = new();
-    private List<Vehicle> _vehicles = new();
-
-    public async Task Open(Invoice invoice, bool isAddMode = false)
-    {
-        _isNew = invoice.Id == 0;
-        _isAddMode = isAddMode; // 請求書追加モードを設定
-        _model = new Invoice
-        {
-            Id = invoice.Id,
-            InvoiceNumber = invoice.InvoiceNumber,
-            Subnumber = invoice.Subnumber,
-            ClientId = invoice.ClientId,
-            VehicleId = invoice.VehicleId,
-            InvoiceDate = invoice.InvoiceDate,
-            WorkCompletedDate = invoice.WorkCompletedDate,
-            NextInspectionDate = invoice.NextInspectionDate,
-            Mileage = invoice.Mileage,
-            Notes = invoice.Notes,
-            TaxRate = invoice.TaxRate,
-            InvoiceDetails = invoice.InvoiceDetails
-        };
-
-        // 顧客リストを取得
-        var clients = await Http.GetFromJsonAsync<AutoDealerSphere.Shared.Models.Client[]>("api/Client");
-        _clients = clients?.ToList() ?? new List<AutoDealerSphere.Shared.Models.Client>();
-
-        // 既存データの場合、車両リストも取得
-        if (_model.ClientId > 0)
-        {
-            await LoadVehicles(_model.ClientId);
-        }
-
-        _isVisible = true;
-        StateHasChanged();
-    }
-
-    private async Task OnClientChanged(Syncfusion.Blazor.DropDowns.ChangeEventArgs<int, AutoDealerSphere.Shared.Models.Client> args)
-    {
-        if (args.Value > 0)
-        {
-            await LoadVehicles(args.Value);
-            _model!.VehicleId = null;
-        }
-    }
-
-    private async Task LoadVehicles(int clientId)
-    {
-        var vehicles = await Http.GetFromJsonAsync<Vehicle[]>($"api/Vehicles/byClient/{clientId}");
-        _vehicles = vehicles?.ToList() ?? new List<Vehicle>();
-    }
-
-    private async Task OnValidSubmit()
-    {
-        if (_model != null)
-        {
-            await OnSave.InvokeAsync(_model);
-            _isVisible = false;
-        }
-    }
-
-    private void Cancel()
-    {
-        _isVisible = false;
-    }
-    
-    private string GetInvoiceNumberDisplay()
-    {
-        if (_model == null) return string.Empty;
-        if (string.IsNullOrEmpty(_model.InvoiceNumber)) return "自動生成";
-        if (_model.Subnumber > 1)
-            return $"{_model.InvoiceNumber}-{_model.Subnumber}";
-        return _model.InvoiceNumber;
-    }
-}

--- a/Client/Components/InvoiceBasicInfoDialog.razor.cs
+++ b/Client/Components/InvoiceBasicInfoDialog.razor.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Components;
+using AutoDealerSphere.Shared.Models;
+using Syncfusion.Blazor.Popups;
+using System.Net.Http.Json;
+
+namespace AutoDealerSphere.Client.Components
+{
+    public partial class InvoiceBasicInfoDialog
+    {
+        [Inject] private HttpClient Http { get; set; } = default!;
+        [Parameter] public EventCallback<Invoice> OnSave { get; set; }
+
+        private SfDialog? _dialog;
+        private bool _isVisible = false;
+        private bool _isNew = false;
+        private bool _isAddMode = false; // 請求書追加モード
+        private Invoice? _model;
+        private List<AutoDealerSphere.Shared.Models.Client> _clients = new();
+        private List<Vehicle> _vehicles = new();
+
+        public async Task Open(Invoice invoice, bool isAddMode = false)
+        {
+            _isNew = invoice.Id == 0;
+            _isAddMode = isAddMode; // 請求書追加モードを設定
+            _model = new Invoice
+            {
+                Id = invoice.Id,
+                InvoiceNumber = invoice.InvoiceNumber,
+                Subnumber = invoice.Subnumber,
+                ClientId = invoice.ClientId,
+                VehicleId = invoice.VehicleId,
+                InvoiceDate = invoice.InvoiceDate,
+                WorkCompletedDate = invoice.WorkCompletedDate,
+                NextInspectionDate = invoice.NextInspectionDate,
+                Mileage = invoice.Mileage,
+                Notes = invoice.Notes,
+                TaxRate = invoice.TaxRate,
+                InvoiceDetails = invoice.InvoiceDetails
+            };
+
+            // 顧客リストを取得
+            var clients = await Http.GetFromJsonAsync<AutoDealerSphere.Shared.Models.Client[]>("api/Client");
+            _clients = clients?.ToList() ?? new List<AutoDealerSphere.Shared.Models.Client>();
+
+            // 既存データの場合、車両リストも取得
+            if (_model.ClientId > 0)
+            {
+                await LoadVehicles(_model.ClientId);
+            }
+
+            _isVisible = true;
+            StateHasChanged();
+        }
+
+        private async Task OnClientChanged(Syncfusion.Blazor.DropDowns.ChangeEventArgs<int, AutoDealerSphere.Shared.Models.Client> args)
+        {
+            if (args.Value > 0)
+            {
+                await LoadVehicles(args.Value);
+                _model!.VehicleId = null;
+            }
+        }
+
+        private async Task LoadVehicles(int clientId)
+        {
+            var vehicles = await Http.GetFromJsonAsync<Vehicle[]>($"api/Vehicles/byClient/{clientId}");
+            _vehicles = vehicles?.ToList() ?? new List<Vehicle>();
+        }
+
+        private async Task OnValidSubmit()
+        {
+            if (_model != null)
+            {
+                await OnSave.InvokeAsync(_model);
+                _isVisible = false;
+            }
+        }
+
+        private void Cancel()
+        {
+            _isVisible = false;
+        }
+
+        private string GetInvoiceNumberDisplay()
+        {
+            if (_model == null) return string.Empty;
+            if (string.IsNullOrEmpty(_model.InvoiceNumber)) return "自動生成";
+            if (_model.Subnumber > 1)
+                return $"{_model.InvoiceNumber}-{_model.Subnumber}";
+            return _model.InvoiceNumber;
+        }
+    }
+}

--- a/Client/Components/InvoiceDetailDialog.razor
+++ b/Client/Components/InvoiceDetailDialog.razor
@@ -12,6 +12,7 @@
             <span>@DialogTitle</span>
         </Header>
         <Content>
+            <div class="invoice-detail-dialog">
             @if (_currentStep == DialogStep.SelectPart)
             {
                 <div class="part-selection">
@@ -127,83 +128,7 @@
                     </EditForm>
                 </div>
             }
+            </div>
         </Content>
     </DialogTemplates>
 </SfDialog>
-
-<style>
-    .part-selection, .detail-editing {
-        padding: 10px;
-    }
-    
-    .search-section {
-        margin-bottom: 20px;
-        padding: 15px;
-        background: #f5f5f5;
-        border-radius: 5px;
-    }
-    
-    .search-section .form-row:last-child {
-        justify-content: flex-end;
-        margin-bottom: 0;
-    }
-    
-    .parts-grid {
-        margin-bottom: 20px;
-        max-height: 300px;
-        overflow-y: auto;
-    }
-    
-    .form-row {
-        display: flex;
-        align-items: center;
-        margin-bottom: 15px;
-        gap: 10px;
-    }
-    
-    .form-row label {
-        width: 100px;
-        color: #333;
-    }
-    
-    .form-row .e-input-group,
-    .form-row .e-numerictextbox,
-    .form-row .e-ddl {
-        flex: 1;
-        max-width: 300px;
-    }
-    
-    .selected-part, .selected-type {
-        font-weight: 500;
-        color: #333;
-    }
-    
-    .subtotal {
-        font-size: 1.1em;
-        font-weight: 500;
-        color: #333;
-    }
-    
-    .dialog-buttons {
-        display: flex;
-        justify-content: center;
-        gap: 10px;
-        margin-top: 20px;
-    }
-    
-    .required::after {
-        content: "必須";
-        color: #ffffff;
-        background: #cc0000;
-        font-size: 0.8em;
-        padding: 0.3em;
-        border-radius: 0.5em;
-        margin-left: 0.3em;
-    }
-    
-    .empty-record {
-        padding: 20px;
-        text-align: center;
-        color: #666;
-    }
-</style>

--- a/Client/wwwroot/css/forms.css
+++ b/Client/wwwroot/css/forms.css
@@ -519,3 +519,67 @@
     text-align: right;
     white-space: nowrap;
 }
+
+/* ダイアログ特有のスタイル */
+.dialog-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+/* 請求書基本情報ダイアログ用 */
+.invoice-basic-info-dialog .form-row .e-input-group,
+.invoice-basic-info-dialog .form-row .e-ddl,
+.invoice-basic-info-dialog .form-row .e-date-wrapper {
+    flex: 1;
+}
+
+/* 請求書明細ダイアログ用 */
+.invoice-detail-dialog .part-selection,
+.invoice-detail-dialog .detail-editing {
+    padding: 10px;
+}
+
+.invoice-detail-dialog .search-section {
+    margin-bottom: 20px;
+    padding: 15px;
+    background: #f5f5f5;
+    border-radius: 5px;
+}
+
+.invoice-detail-dialog .search-section .form-row:last-child {
+    justify-content: flex-end;
+    margin-bottom: 0;
+}
+
+.invoice-detail-dialog .parts-grid {
+    margin-bottom: 20px;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.invoice-detail-dialog .form-row .e-input-group,
+.invoice-detail-dialog .form-row .e-numerictextbox,
+.invoice-detail-dialog .form-row .e-ddl {
+    flex: 1;
+    max-width: 300px;
+}
+
+.invoice-detail-dialog .selected-part,
+.invoice-detail-dialog .selected-type {
+    font-weight: 500;
+    color: #333;
+}
+
+.invoice-detail-dialog .subtotal {
+    font-size: 1.1em;
+    font-weight: 500;
+    color: #333;
+}
+
+.invoice-detail-dialog .empty-record {
+    padding: 20px;
+    text-align: center;
+    color: #666;
+}


### PR DESCRIPTION
## Summary
- 条件付きedit-modeクラスを削除し、新規と編集で統一されたレイアウトを実現
- 両ダイアログからインラインCSSを削除
- InvoiceBasicInfoDialogのC#コードをcode-behindファイルに移動
- ダイアログ特有のスタイルをforms.cssに追加

Closes #86

Generated with [Claude Code](https://claude.ai/code)