### PR TITLE
fix: データ読み込み前に「××情報がありません」を表示しないよう修正

### DIFF
--- a/Client/Pages/ClientList.razor
+++ b/Client/Pages/ClientList.razor
@@ -53,7 +53,7 @@
 </div>
 <br />
 
-@if (Clients.Any())
+@if (Clients != null && Clients.Any())
 {
     <SfGrid DataSource="@Clients" AllowPaging="true" AllowSorting="true" AllowMultiSorting="true" CssClass="two-line-grid">
         <GridTemplates>
@@ -109,7 +109,7 @@
         </GridColumns>
     </SfGrid>
 }
-else
+else if (Clients != null)
 {
     <p class="error-message">顧客情報が見つかりません。</p>
 }

--- a/Client/Pages/ClientList.razor.cs
+++ b/Client/Pages/ClientList.razor.cs
@@ -7,7 +7,7 @@ namespace AutoDealerSphere.Client.Pages
 {
     public partial class ClientList
     {
-        private List<AutoDealerSphere.Shared.Models.Client> Clients { get; set; } = new();
+        private List<AutoDealerSphere.Shared.Models.Client>? Clients { get; set; } = null;
         private AutoDealerSphere.Shared.Models.ClientSearch Search { get; set; } = new();
 
         protected override async Task OnInitializedAsync()
@@ -40,30 +40,30 @@ namespace AutoDealerSphere.Client.Pages
                     await LoadData();
                     
                     // 名前またはカナの部分一致
-                    if (!string.IsNullOrEmpty(search.NameOrKana))
+                    if (!string.IsNullOrEmpty(search.NameOrKana) && Clients != null)
                     {
-                        Clients = Clients.Where(c => 
-                            c.Name.Contains(search.NameOrKana) || 
+                        Clients = Clients.Where(c =>
+                            c.Name.Contains(search.NameOrKana) ||
                             (c.Kana != null && c.Kana.Contains(search.NameOrKana))
                         ).ToList();
                     }
-                    
+
                     // メールアドレスの部分一致
-                    if (!string.IsNullOrEmpty(search.Email))
+                    if (!string.IsNullOrEmpty(search.Email) && Clients != null)
                     {
                         Clients = Clients.Where(c => c.Email.Contains(search.Email)).ToList();
                     }
-                    
+
                     // 電話番号の部分一致
-                    if (!string.IsNullOrEmpty(search.Phone))
+                    if (!string.IsNullOrEmpty(search.Phone) && Clients != null)
                     {
                         Clients = Clients.Where(c => c.Phone != null && c.Phone.Contains(search.Phone)).ToList();
                     }
-                    
+
                     // 住所の部分一致（郵便番号、都道府県、住所）
-                    if (!string.IsNullOrEmpty(search.Address))
+                    if (!string.IsNullOrEmpty(search.Address) && Clients != null)
                     {
-                        Clients = Clients.Where(c => 
+                        Clients = Clients.Where(c =>
                             c.Zip.Contains(search.Address) ||
                             GetPrefectureName(c.Prefecture).Contains(search.Address) ||
                             c.Address.Contains(search.Address)

--- a/Client/Pages/InvoiceList.razor
+++ b/Client/Pages/InvoiceList.razor
@@ -116,7 +116,7 @@
         </GridColumns>
     </SfGrid>
 }
-else
+else if (SearchResults != null)
 {
     <p class="error-message">請求書情報が見つかりません。</p>
 }

--- a/Client/Pages/PartList.razor
+++ b/Client/Pages/PartList.razor
@@ -72,7 +72,7 @@
         </GridColumns>
     </SfGrid>
 }
-else
+else if (Parts != null)
 {
     <p class="error-message">部品情報が見つかりません。</p>
 }

--- a/Client/Pages/UserList.razor
+++ b/Client/Pages/UserList.razor
@@ -45,7 +45,7 @@
 </div>
 <br />
 
-@if (Users.Any())
+@if (Users != null && Users.Any())
 {
     <SfGrid DataSource="@Users" AllowPaging="true" AllowSorting="true" AllowMultiSorting="true" CssClass="user-grid">
         <GridTemplates>
@@ -78,7 +78,7 @@
         </GridColumns>
     </SfGrid>
 }
-else
+else if (Users != null)
 {
     <p class="error-message">ユーザー情報が見つかりません。</p>
 }

--- a/Client/Pages/UserList.razor.cs
+++ b/Client/Pages/UserList.razor.cs
@@ -7,7 +7,7 @@ namespace AutoDealerSphere.Client.Pages
 {
     public partial class UserList
     {
-        private List<User> Users { get; set; } = new();
+        private List<User>? Users { get; set; } = null;
         private UserSearch Search { get; set; } = new();
 
         protected override async Task OnInitializedAsync()
@@ -40,13 +40,13 @@ namespace AutoDealerSphere.Client.Pages
                     await LoadData();
                     
                     // 名前の部分一致
-                    if (!string.IsNullOrEmpty(search.Name))
+                    if (!string.IsNullOrEmpty(search.Name) && Users != null)
                     {
                         Users = Users.Where(u => u.Name.Contains(search.Name)).ToList();
                     }
-                    
+
                     // メールアドレスの部分一致
-                    if (!string.IsNullOrEmpty(search.Email))
+                    if (!string.IsNullOrEmpty(search.Email) && Users != null)
                     {
                         Users = Users.Where(u => u.Email.Contains(search.Email)).ToList();
                     }

--- a/Client/Pages/VehicleList.razor
+++ b/Client/Pages/VehicleList.razor
@@ -60,7 +60,7 @@
 </div>
 <br />
 
-@if (Vehicles.Any())
+@if (Vehicles != null && Vehicles.Any())
 {
     <SfGrid DataSource="@Vehicles" AllowPaging="true" AllowSorting="true" AllowMultiSorting="true" CssClass="two-line-grid">
         <GridTemplates>
@@ -118,7 +118,7 @@
         </GridColumns>
     </SfGrid>
 }
-else
+else if (Vehicles != null)
 {
     <p class="error-message">車両情報が見つかりません。</p>
 }

--- a/Client/Pages/VehicleList.razor.cs
+++ b/Client/Pages/VehicleList.razor.cs
@@ -6,7 +6,7 @@ namespace AutoDealerSphere.Client.Pages
 {
     public partial class VehicleList : ComponentBase
     {
-        private List<Vehicle> Vehicles = new();
+        private List<Vehicle>? Vehicles = null;
         private VehicleSearchModel Search = new();
 
         protected override async Task OnInitializedAsync()


### PR DESCRIPTION
## Summary
各一覧ページでデータ読み込み前に「××情報がありません」が一瞬表示される問題を修正しました。

## Changes
- リストプロパティをnullableに変更
- データ読み込み完了後のみ「××情報がありません」を表示
- 検索機能のnullチェックを追加

Closes #92

Generated with [Claude Code](https://claude.ai/code)