### PR TITLE
fix: データ管理メニューにフォルダーアイコンを追加

### DIFF
--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -101,7 +101,7 @@
         new AutoDealerSphere.Client.Shared.MenuItems()
         {
             Text = "データ管理",
-            IconCss = "e-icons e-database",
+            IconCss = "e-icons e-folder",
             Items = new List<AutoDealerSphere.Client.Shared.MenuItems>()
             {
                 new AutoDealerSphere.Client.Shared.MenuItems()


### PR DESCRIPTION
### 概要

データ管理メニューにアイコンが表示されない問題を修正しました。

### 問題の原因

`e-database` というアイコンクラスがSyncfusionのアイコンセットに存在していませんでした。

### 修正内容

- アイコンクラスを `e-icons e-database` から `e-icons e-folder` に変更
- `e-folder` はSyncfusionの標準アイコンで、データ管理機能に適したフォルダーアイコンです

Closes #108

🤖 Generated with [Claude Code](https://claude.ai/code)