### PR TITLE
メール送信機能とパスワードリセット機能を実装

### DIFF
--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -150,6 +150,12 @@
         },
         new AutoDealerSphere.Client.Shared.MenuItems()
         {
+            Text = "メール設定",
+            Url = "/email-settings",
+            IconCss = "e-icons e-mail"
+        },
+        new AutoDealerSphere.Client.Shared.MenuItems()
+        {
             Text = "ログアウト",
             Url = "/",
             IconCss = "e-icons e-close"

--- a/Client/Pages/EmailSettings.razor
+++ b/Client/Pages/EmailSettings.razor
@@ -1,0 +1,80 @@
+@page "/email-settings"
+@using AutoDealerSphere.Client.Shared
+@using Syncfusion.Blazor.Navigations
+@using Syncfusion.Blazor.Inputs
+@using Syncfusion.Blazor.Buttons
+
+<SfBreadcrumb>
+    <BreadcrumbItems>
+        <BreadcrumbItem IconCss="e-icons e-home" Url="/" />
+        <BreadcrumbItem Text="メール設定" Url="/" />
+    </BreadcrumbItems>
+</SfBreadcrumb>
+
+<h2>メール設定</h2>
+
+@if (!string.IsNullOrEmpty(errorMessage))
+{
+    <div class="alert alert-danger">@errorMessage</div>
+}
+
+@if (!string.IsNullOrEmpty(successMessage))
+{
+    <div class="alert alert-success">@successMessage</div>
+}
+
+<div class="form-group">
+    <label>SMTPホスト</label>
+    <SfTextBox @bind-Value="@emailSettings.SmtpHost" Placeholder="例: smtp.gmail.com"></SfTextBox>
+</div>
+
+<div class="form-group">
+    <label>SMTPポート</label>
+    <SfNumericTextBox @bind-Value="@emailSettings.SmtpPort" Min="1" Max="65535" Format="n0"></SfNumericTextBox>
+</div>
+
+<div class="form-group">
+    <label>
+        <SfCheckBox @bind-Checked="@emailSettings.EnableSsl"></SfCheckBox>
+        SSL/TLS使用
+    </label>
+</div>
+
+<div class="form-group">
+    <label>送信者メールアドレス</label>
+    <SfTextBox @bind-Value="@emailSettings.SenderEmail" Placeholder="例: noreply@example.com"></SfTextBox>
+</div>
+
+<div class="form-group">
+    <label>送信者名</label>
+    <SfTextBox @bind-Value="@emailSettings.SenderName" Placeholder="例: AutoDealerSphere"></SfTextBox>
+</div>
+
+<div class="form-group">
+    <label>SMTP認証ユーザー名</label>
+    <SfTextBox @bind-Value="@emailSettings.Username" Placeholder="SMTP認証用のユーザー名"></SfTextBox>
+</div>
+
+<div class="form-group">
+    <label>SMTP認証パスワード</label>
+    <SfTextBox @bind-Value="@password" Type="InputType.Password" Placeholder="SMTP認証用のパスワード"></SfTextBox>
+</div>
+
+<div class="form-group">
+    <label>テストメール送信先</label>
+    <SfTextBox @bind-Value="@testEmailAddress" Placeholder="テストメールの送信先アドレス"></SfTextBox>
+</div>
+
+<div class="button-group">
+    <SfButton CssClass="e-primary" OnClick="SaveSettings" Disabled="@isProcessing">保存</SfButton>
+    <SfButton CssClass="e-info" OnClick="TestConnection" Disabled="@isProcessing">接続テスト</SfButton>
+    <SfButton CssClass="e-success" OnClick="SendTestEmail" Disabled="@isProcessing">テストメール送信</SfButton>
+</div>
+
+@code {
+    private string password = "";
+    private string testEmailAddress = "";
+    private string errorMessage = "";
+    private string successMessage = "";
+    private bool isProcessing = false;
+}

--- a/Client/Pages/EmailSettings.razor.cs
+++ b/Client/Pages/EmailSettings.razor.cs
@@ -1,0 +1,194 @@
+using AutoDealerSphere.Shared.Models;
+using Microsoft.AspNetCore.Components;
+using System.Net.Http.Json;
+
+namespace AutoDealerSphere.Client.Pages
+{
+    public partial class EmailSettings
+    {
+        [Inject]
+        private HttpClient Http { get; set; }
+
+        [Inject]
+        private NavigationManager Navigation { get; set; }
+
+        private EmailSettingsModel emailSettings = new EmailSettingsModel();
+
+        protected override async Task OnInitializedAsync()
+        {
+            await LoadSettings();
+        }
+
+        private async Task LoadSettings()
+        {
+            try
+            {
+                var response = await Http.GetFromJsonAsync<EmailSettingsModel>("api/EmailSettings");
+                if (response != null)
+                {
+                    emailSettings = response;
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"設定の読み込みに失敗しました: {ex.Message}";
+            }
+        }
+
+        private async Task SaveSettings()
+        {
+            if (string.IsNullOrEmpty(password))
+            {
+                errorMessage = "パスワードを入力してください。";
+                return;
+            }
+
+            isProcessing = true;
+            errorMessage = "";
+            successMessage = "";
+
+            try
+            {
+                var request = new EmailSettingsRequestModel
+                {
+                    Settings = emailSettings,
+                    PlainPassword = password
+                };
+
+                var response = await Http.PostAsJsonAsync("api/EmailSettings", request);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    successMessage = "設定を保存しました。";
+                    password = ""; // セキュリティのためクリア
+                }
+                else
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    errorMessage = $"保存に失敗しました: {errorContent}";
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"保存中にエラーが発生しました: {ex.Message}";
+            }
+            finally
+            {
+                isProcessing = false;
+            }
+        }
+
+        private async Task TestConnection()
+        {
+            if (string.IsNullOrEmpty(password))
+            {
+                errorMessage = "パスワードを入力してください。";
+                return;
+            }
+
+            isProcessing = true;
+            errorMessage = "";
+            successMessage = "";
+
+            try
+            {
+                var request = new EmailSettingsRequestModel
+                {
+                    Settings = emailSettings,
+                    PlainPassword = password
+                };
+
+                var response = await Http.PostAsJsonAsync("api/EmailSettings/test-connection", request);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var result = await response.Content.ReadFromJsonAsync<bool>();
+                    if (result)
+                    {
+                        successMessage = "接続テストに成功しました。";
+                    }
+                    else
+                    {
+                        errorMessage = "接続テストに失敗しました。設定を確認してください。";
+                    }
+                }
+                else
+                {
+                    errorMessage = "接続テストに失敗しました。";
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"接続テスト中にエラーが発生しました: {ex.Message}";
+            }
+            finally
+            {
+                isProcessing = false;
+            }
+        }
+
+        private async Task SendTestEmail()
+        {
+            if (string.IsNullOrEmpty(testEmailAddress))
+            {
+                errorMessage = "テストメール送信先を入力してください。";
+                return;
+            }
+
+            isProcessing = true;
+            errorMessage = "";
+            successMessage = "";
+
+            try
+            {
+                var response = await Http.PostAsJsonAsync("api/EmailSettings/send-test-email", testEmailAddress);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var result = await response.Content.ReadFromJsonAsync<bool>();
+                    if (result)
+                    {
+                        successMessage = $"テストメールを送信しました: {testEmailAddress}";
+                    }
+                    else
+                    {
+                        errorMessage = "テストメール送信に失敗しました。";
+                    }
+                }
+                else
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    errorMessage = $"テストメール送信に失敗しました: {errorContent}";
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"テストメール送信中にエラーが発生しました: {ex.Message}";
+            }
+            finally
+            {
+                isProcessing = false;
+            }
+        }
+    }
+
+    // クライアント側のモデル（Shared/Modelsと同じ構造）
+    public class EmailSettingsModel
+    {
+        public int Id { get; set; }
+        public string SmtpHost { get; set; } = "";
+        public int SmtpPort { get; set; } = 587;
+        public bool EnableSsl { get; set; } = true;
+        public string SenderEmail { get; set; } = "";
+        public string SenderName { get; set; } = "";
+        public string Username { get; set; } = "";
+        public string EncryptedPassword { get; set; } = "";
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public class EmailSettingsRequestModel
+    {
+        public EmailSettingsModel Settings { get; set; } = new EmailSettingsModel();
+        public string PlainPassword { get; set; } = "";
+    }
+}

--- a/Client/Pages/ForgotPassword.razor
+++ b/Client/Pages/ForgotPassword.razor
@@ -1,0 +1,51 @@
+@page "/forgot-password"
+@using Syncfusion.Blazor.Inputs
+@using Syncfusion.Blazor.Buttons
+
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header">
+                    <h3>パスワードを忘れた場合</h3>
+                </div>
+                <div class="card-body">
+                    @if (!emailSent)
+                    {
+                        <p>登録されているメールアドレスを入力してください。パスワードリセット用のリンクをお送りします。</p>
+
+                        @if (!string.IsNullOrEmpty(errorMessage))
+                        {
+                            <div class="alert alert-danger">@errorMessage</div>
+                        }
+
+                        <div class="form-group">
+                            <label>メールアドレス</label>
+                            <SfTextBox @bind-Value="@email" Placeholder="メールアドレスを入力してください"></SfTextBox>
+                        </div>
+
+                        <div class="button-group mt-3">
+                            <SfButton CssClass="e-primary" OnClick="SendResetEmail" Disabled="@isProcessing">送信</SfButton>
+                            <SfButton CssClass="e-outline" OnClick="GoToLogin">ログインに戻る</SfButton>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="alert alert-success">
+                            <p>メールアドレスが登録されている場合、パスワードリセットのメールを送信しました。</p>
+                            <p>メールをご確認ください。</p>
+                        </div>
+                        <SfButton CssClass="e-primary" OnClick="GoToLogin">ログインに戻る</SfButton>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    private string email = "";
+    private string errorMessage = "";
+    private bool isProcessing = false;
+    private bool emailSent = false;
+}

--- a/Client/Pages/ForgotPassword.razor.cs
+++ b/Client/Pages/ForgotPassword.razor.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Components;
+using System.Net.Http.Json;
+
+namespace AutoDealerSphere.Client.Pages
+{
+    public partial class ForgotPassword
+    {
+        [Inject]
+        private HttpClient Http { get; set; }
+
+        [Inject]
+        private NavigationManager Navigation { get; set; }
+
+        private async Task SendResetEmail()
+        {
+            if (string.IsNullOrEmpty(email))
+            {
+                errorMessage = "メールアドレスを入力してください。";
+                return;
+            }
+
+            isProcessing = true;
+            errorMessage = "";
+
+            try
+            {
+                var baseUrl = Navigation.BaseUri.TrimEnd('/');
+                var request = new PasswordResetRequestModel
+                {
+                    Email = email,
+                    BaseUrl = baseUrl
+                };
+
+                var response = await Http.PostAsJsonAsync("api/PasswordReset/request", request);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    emailSent = true;
+                }
+                else
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    errorMessage = $"送信に失敗しました: {errorContent}";
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"送信中にエラーが発生しました。メール設定を確認してください。";
+                Console.WriteLine($"Error: {ex.Message}");
+            }
+            finally
+            {
+                isProcessing = false;
+            }
+        }
+
+        private void GoToLogin()
+        {
+            Navigation.NavigateTo("/login");
+        }
+    }
+
+    public class PasswordResetRequestModel
+    {
+        public string Email { get; set; } = "";
+        public string BaseUrl { get; set; } = "";
+    }
+}

--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -32,9 +32,13 @@
         {
             <div class="error-message">@errorMessage</div>
         }
-        
+
         <div class="form-buttons">
             <SfButton CssClass="e-primary" OnClick="HandleLogin">ログイン</SfButton>
+        </div>
+
+        <div class="forgot-password-link">
+            <a href="/forgot-password">パスワードを忘れた場合</a>
         </div>
     </div>
 </div>
@@ -110,6 +114,21 @@
         text-align: center;
         margin-top: 10px;
         font-size: 14px;
+    }
+
+    .forgot-password-link {
+        text-align: center;
+        margin-top: 15px;
+    }
+
+    .forgot-password-link a {
+        color: #1976d2;
+        text-decoration: none;
+        font-size: 14px;
+    }
+
+    .forgot-password-link a:hover {
+        text-decoration: underline;
     }
 </style>
 

--- a/Client/Pages/ResetPassword.razor
+++ b/Client/Pages/ResetPassword.razor
@@ -1,0 +1,73 @@
+@page "/reset-password"
+@using Syncfusion.Blazor.Inputs
+@using Syncfusion.Blazor.Buttons
+
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header">
+                    <h3>パスワードリセット</h3>
+                </div>
+                <div class="card-body">
+                    @if (!passwordReset)
+                    {
+                        @if (isValidToken)
+                        {
+                            @if (!string.IsNullOrEmpty(errorMessage))
+                            {
+                                <div class="alert alert-danger">@errorMessage</div>
+                            }
+
+                            <p>新しいパスワードを入力してください。</p>
+
+                            <div class="form-group">
+                                <label>新しいパスワード</label>
+                                <SfTextBox @bind-Value="@newPassword" Type="InputType.Password" Placeholder="新しいパスワード"></SfTextBox>
+                            </div>
+
+                            <div class="form-group">
+                                <label>新しいパスワード（確認）</label>
+                                <SfTextBox @bind-Value="@confirmPassword" Type="InputType.Password" Placeholder="新しいパスワード（確認）"></SfTextBox>
+                            </div>
+
+                            <div class="button-group mt-3">
+                                <SfButton CssClass="e-primary" OnClick="ResetPasswordAsync" Disabled="@isProcessing">パスワードをリセット</SfButton>
+                                <SfButton CssClass="e-outline" OnClick="GoToLogin">キャンセル</SfButton>
+                            </div>
+                        }
+                        else if (isLoading)
+                        {
+                            <p>トークンを検証中...</p>
+                        }
+                        else
+                        {
+                            <div class="alert alert-danger">
+                                <p>@errorMessage</p>
+                            </div>
+                            <SfButton CssClass="e-primary" OnClick="GoToLogin">ログインに戻る</SfButton>
+                        }
+                    }
+                    else
+                    {
+                        <div class="alert alert-success">
+                            <p>パスワードが正常にリセットされました。</p>
+                            <p>新しいパスワードでログインしてください。</p>
+                        </div>
+                        <SfButton CssClass="e-primary" OnClick="GoToLogin">ログイン</SfButton>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    private string newPassword = "";
+    private string confirmPassword = "";
+    private string errorMessage = "";
+    private bool isProcessing = false;
+    private bool passwordReset = false;
+    private bool isValidToken = false;
+    private bool isLoading = true;
+}

--- a/Client/Pages/ResetPassword.razor.cs
+++ b/Client/Pages/ResetPassword.razor.cs
@@ -1,0 +1,127 @@
+using Microsoft.AspNetCore.Components;
+using System.Net.Http.Json;
+
+namespace AutoDealerSphere.Client.Pages
+{
+    public partial class ResetPassword
+    {
+        [Inject]
+        private HttpClient Http { get; set; }
+
+        [Inject]
+        private NavigationManager Navigation { get; set; }
+
+        private string token = "";
+
+        protected override async Task OnInitializedAsync()
+        {
+            // URLからトークンを取得
+            var uri = new Uri(Navigation.Uri);
+            var query = uri.Query;
+
+            if (!string.IsNullOrEmpty(query) && query.Contains("token="))
+            {
+                var tokenIndex = query.IndexOf("token=") + 6;
+                var endIndex = query.IndexOf('&', tokenIndex);
+                token = endIndex > 0 ? query.Substring(tokenIndex, endIndex - tokenIndex) : query.Substring(tokenIndex);
+                token = Uri.UnescapeDataString(token);
+                await VerifyToken();
+            }
+            else
+            {
+                errorMessage = "無効なリンクです。";
+                isLoading = false;
+            }
+        }
+
+        private async Task VerifyToken()
+        {
+            try
+            {
+                var response = await Http.GetAsync($"api/PasswordReset/verify/{token}");
+
+                if (response.IsSuccessStatusCode)
+                {
+                    isValidToken = true;
+                }
+                else
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    errorMessage = "トークンが無効または期限切れです。";
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"エラーが発生しました: {ex.Message}";
+            }
+            finally
+            {
+                isLoading = false;
+            }
+        }
+
+        private async Task ResetPasswordAsync()
+        {
+            if (string.IsNullOrEmpty(newPassword))
+            {
+                errorMessage = "新しいパスワードを入力してください。";
+                return;
+            }
+
+            if (newPassword != confirmPassword)
+            {
+                errorMessage = "パスワードが一致しません。";
+                return;
+            }
+
+            if (newPassword.Length < 6)
+            {
+                errorMessage = "パスワードは6文字以上で入力してください。";
+                return;
+            }
+
+            isProcessing = true;
+            errorMessage = "";
+
+            try
+            {
+                var request = new ResetPasswordRequestModel
+                {
+                    Token = token,
+                    NewPassword = newPassword
+                };
+
+                var response = await Http.PostAsJsonAsync("api/PasswordReset/reset", request);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    passwordReset = true;
+                }
+                else
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    errorMessage = $"パスワードリセットに失敗しました: {errorContent}";
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"エラーが発生しました: {ex.Message}";
+            }
+            finally
+            {
+                isProcessing = false;
+            }
+        }
+
+        private void GoToLogin()
+        {
+            Navigation.NavigateTo("/login");
+        }
+    }
+
+    public class ResetPasswordRequestModel
+    {
+        public string Token { get; set; } = "";
+        public string NewPassword { get; set; } = "";
+    }
+}

--- a/Server/AutoDealerSphere.Server.csproj
+++ b/Server/AutoDealerSphere.Server.csproj
@@ -9,9 +9,11 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
+    <PackageReference Include="MailKit" Version="4.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.4" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
+    <PackageReference Include="MimeKit" Version="4.9.0" />
     <PackageReference Include="Syncfusion.XlsIO.Net.Core" Version="30.1.41" />
   </ItemGroup>
 

--- a/Server/Controllers/EmailSettingsController.cs
+++ b/Server/Controllers/EmailSettingsController.cs
@@ -1,0 +1,87 @@
+using AutoDealerSphere.Server.Services;
+using AutoDealerSphere.Shared.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AutoDealerSphere.Server.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class EmailSettingsController : ControllerBase
+    {
+        private readonly IEmailSettingsService _emailSettingsService;
+        private readonly IEmailService _emailService;
+
+        public EmailSettingsController(
+            IEmailSettingsService emailSettingsService,
+            IEmailService emailService)
+        {
+            _emailSettingsService = emailSettingsService;
+            _emailService = emailService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<EmailSettings>> GetEmailSettings()
+        {
+            var settings = await _emailSettingsService.GetSettingsAsync();
+            if (settings == null)
+            {
+                return Ok(new EmailSettings());
+            }
+            // パスワードは返さない（セキュリティのため）
+            settings.EncryptedPassword = "";
+            return Ok(settings);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<EmailSettings>> CreateOrUpdateEmailSettings([FromBody] EmailSettingsRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var result = await _emailSettingsService.CreateOrUpdateSettingsAsync(
+                request.Settings,
+                request.PlainPassword);
+
+            // パスワードは返さない
+            result.EncryptedPassword = "";
+            return Ok(result);
+        }
+
+        [HttpPost("test-connection")]
+        public async Task<ActionResult<bool>> TestConnection([FromBody] EmailSettingsRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var result = await _emailSettingsService.TestConnectionAsync(
+                request.Settings,
+                request.PlainPassword);
+
+            return Ok(result);
+        }
+
+        [HttpPost("send-test-email")]
+        public async Task<ActionResult<bool>> SendTestEmail([FromBody] string toEmail)
+        {
+            try
+            {
+                var result = await _emailService.SendTestEmailAsync(toEmail);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { error = ex.Message });
+            }
+        }
+    }
+
+    public class EmailSettingsRequest
+    {
+        public EmailSettings Settings { get; set; } = new EmailSettings();
+        public string PlainPassword { get; set; } = "";
+    }
+}

--- a/Server/Controllers/PasswordResetController.cs
+++ b/Server/Controllers/PasswordResetController.cs
@@ -1,0 +1,145 @@
+using AutoDealerSphere.Server.Services;
+using AutoDealerSphere.Shared.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace AutoDealerSphere.Server.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PasswordResetController : ControllerBase
+    {
+        private readonly SQLDBContext _context;
+        private readonly IEmailService _emailService;
+        private readonly ILogger<PasswordResetController> _logger;
+
+        public PasswordResetController(
+            SQLDBContext context,
+            IEmailService emailService,
+            ILogger<PasswordResetController> logger)
+        {
+            _context = context;
+            _emailService = emailService;
+            _logger = logger;
+        }
+
+        [HttpPost("request")]
+        public async Task<ActionResult> RequestPasswordReset([FromBody] PasswordResetRequest request)
+        {
+            try
+            {
+                var user = await _context.Users
+                    .FirstOrDefaultAsync(u => u.Email == request.Email);
+
+                // セキュリティのため、ユーザーが存在しない場合も同じメッセージを返す
+                if (user != null)
+                {
+                    // 既存の未使用トークンを無効化
+                    var existingTokens = await _context.PasswordResetTokens
+                        .Where(t => t.UserId == user.Id && !t.IsUsed)
+                        .ToListAsync();
+
+                    foreach (var token in existingTokens)
+                    {
+                        token.IsUsed = true;
+                    }
+
+                    // 新しいトークンを作成
+                    var resetToken = new PasswordResetToken
+                    {
+                        UserId = user.Id,
+                        Token = Guid.NewGuid().ToString(),
+                        CreatedAt = DateTime.Now,
+                        ExpiresAt = DateTime.Now.AddHours(1),
+                        IsUsed = false
+                    };
+
+                    _context.PasswordResetTokens.Add(resetToken);
+                    await _context.SaveChangesAsync();
+
+                    // メール送信
+                    var resetUrl = $"{request.BaseUrl}/reset-password";
+                    await _emailService.SendPasswordResetEmailAsync(
+                        user.Email,
+                        resetToken.Token,
+                        resetUrl);
+
+                    _logger.LogInformation($"パスワードリセットメールを送信しました: {user.Email}");
+                }
+
+                // 常に同じメッセージを返す（情報漏洩防止）
+                return Ok(new { message = "メールアドレスが登録されている場合、パスワードリセットのメールを送信しました。" });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "パスワードリセット要求処理中にエラーが発生しました");
+                return StatusCode(500, new { error = "メール送信に失敗しました。メール設定を確認してください。" });
+            }
+        }
+
+        [HttpGet("verify/{token}")]
+        public async Task<ActionResult> VerifyResetToken(string token)
+        {
+            var resetToken = await _context.PasswordResetTokens
+                .Include(t => t.User)
+                .FirstOrDefaultAsync(t => t.Token == token && !t.IsUsed);
+
+            if (resetToken == null)
+            {
+                return BadRequest(new { error = "無効なトークンです。" });
+            }
+
+            if (resetToken.ExpiresAt < DateTime.Now)
+            {
+                return BadRequest(new { error = "トークンの有効期限が切れています。" });
+            }
+
+            return Ok(new { valid = true, email = resetToken.User?.Email });
+        }
+
+        [HttpPost("reset")]
+        public async Task<ActionResult> ResetPassword([FromBody] ResetPasswordRequest request)
+        {
+            var resetToken = await _context.PasswordResetTokens
+                .Include(t => t.User)
+                .FirstOrDefaultAsync(t => t.Token == request.Token && !t.IsUsed);
+
+            if (resetToken == null)
+            {
+                return BadRequest(new { error = "無効なトークンです。" });
+            }
+
+            if (resetToken.ExpiresAt < DateTime.Now)
+            {
+                return BadRequest(new { error = "トークンの有効期限が切れています。" });
+            }
+
+            if (resetToken.User == null)
+            {
+                return BadRequest(new { error = "ユーザーが見つかりません。" });
+            }
+
+            // パスワードを更新
+            resetToken.User.Password = PasswordHashService.HashPassword(request.NewPassword);
+            resetToken.IsUsed = true;
+
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation($"パスワードがリセットされました: {resetToken.User.Email}");
+
+            return Ok(new { message = "パスワードが正常にリセットされました。" });
+        }
+    }
+
+    public class PasswordResetRequest
+    {
+        public string Email { get; set; } = "";
+        public string BaseUrl { get; set; } = "";
+    }
+
+    public class ResetPasswordRequest
+    {
+        public string Token { get; set; } = "";
+        public string NewPassword { get; set; } = "";
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddControllersWithViews()
     });
 builder.Services.AddRazorPages();
 builder.Services.AddDbContextFactory<SQLDBContext>(options => options.UseSqlite(connectionString));
+builder.Services.AddDataProtection();
 builder.Services.AddScoped<IClientService, ClientService>();
 builder.Services.AddScoped<IVehicleImportService, VehicleImportService>();
 builder.Services.AddScoped<IPartService, PartService>();
@@ -24,6 +25,8 @@ builder.Services.AddScoped<IExcelExportService, ExcelExportService>();
 builder.Services.AddScoped<IStatutoryFeeService, StatutoryFeeService>();
 builder.Services.AddScoped<IIssuerInfoService, IssuerInfoService>();
 builder.Services.AddScoped<IDataManagementService, DataManagementService>();
+builder.Services.AddScoped<IEmailSettingsService, EmailSettingsService>();
+builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<JwtService>();
 
 var app = builder.Build();

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -1,0 +1,85 @@
+using MailKit.Net.Smtp;
+using MimeKit;
+using MimeKit.Text;
+
+namespace AutoDealerSphere.Server.Services
+{
+    public class EmailService : IEmailService
+    {
+        private readonly IEmailSettingsService _settingsService;
+        private readonly ILogger<EmailService> _logger;
+
+        public EmailService(IEmailSettingsService settingsService, ILogger<EmailService> logger)
+        {
+            _settingsService = settingsService;
+            _logger = logger;
+        }
+
+        public async Task SendPasswordResetEmailAsync(string toEmail, string resetToken, string resetUrl)
+        {
+            var subject = "パスワードリセットのご依頼";
+            var body = $@"
+                <h2>パスワードリセットのご依頼</h2>
+                <p>パスワードリセットのリクエストを受け付けました。</p>
+                <p>以下のリンクをクリックして、新しいパスワードを設定してください：</p>
+                <p><a href='{resetUrl}?token={resetToken}'>パスワードをリセット</a></p>
+                <p>このリンクは1時間有効です。</p>
+                <p>※このメールに心当たりがない場合は、無視してください。</p>
+            ";
+
+            await SendEmailAsync(toEmail, subject, body);
+        }
+
+        public async Task SendEmailAsync(string toEmail, string subject, string htmlBody)
+        {
+            var settings = await _settingsService.GetSettingsAsync();
+            if (settings == null)
+            {
+                throw new InvalidOperationException("メール設定が登録されていません。");
+            }
+
+            var password = await _settingsService.DecryptPasswordAsync(settings.EncryptedPassword);
+
+            var message = new MimeMessage();
+            message.From.Add(new MailboxAddress(settings.SenderName, settings.SenderEmail));
+            message.To.Add(new MailboxAddress("", toEmail));
+            message.Subject = subject;
+            message.Body = new TextPart(TextFormat.Html) { Text = htmlBody };
+
+            using var client = new SmtpClient();
+            try
+            {
+                await client.ConnectAsync(settings.SmtpHost, settings.SmtpPort, settings.EnableSsl);
+                await client.AuthenticateAsync(settings.Username, password);
+                await client.SendAsync(message);
+                await client.DisconnectAsync(true);
+                _logger.LogInformation($"メール送信成功: {toEmail}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"メール送信失敗: {toEmail}");
+                throw;
+            }
+        }
+
+        public async Task<bool> SendTestEmailAsync(string toEmail)
+        {
+            try
+            {
+                var subject = "テストメール";
+                var body = @"
+                    <h2>テストメール</h2>
+                    <p>これはAutoDealerSphereからのテストメールです。</p>
+                    <p>メール設定が正しく動作しています。</p>
+                ";
+                await SendEmailAsync(toEmail, subject, body);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "テストメール送信に失敗しました");
+                return false;
+            }
+        }
+    }
+}

--- a/Server/Services/EmailSettingsService.cs
+++ b/Server/Services/EmailSettingsService.cs
@@ -1,0 +1,72 @@
+using AutoDealerSphere.Shared.Models;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using MailKit.Net.Smtp;
+
+namespace AutoDealerSphere.Server.Services
+{
+    public class EmailSettingsService : IEmailSettingsService
+    {
+        private readonly SQLDBContext _context;
+        private readonly IDataProtector _protector;
+        private readonly ILogger<EmailSettingsService> _logger;
+
+        public EmailSettingsService(
+            SQLDBContext context,
+            IDataProtectionProvider dataProtectionProvider,
+            ILogger<EmailSettingsService> logger)
+        {
+            _context = context;
+            _protector = dataProtectionProvider.CreateProtector("EmailSettings.Password");
+            _logger = logger;
+        }
+
+        public async Task<EmailSettings?> GetSettingsAsync()
+        {
+            return await _context.EmailSettings.FirstOrDefaultAsync();
+        }
+
+        public async Task<EmailSettings> CreateOrUpdateSettingsAsync(EmailSettings settings, string plainPassword)
+        {
+            settings.EncryptedPassword = _protector.Protect(plainPassword);
+            settings.UpdatedAt = DateTime.Now;
+
+            var existing = await _context.EmailSettings.FirstOrDefaultAsync();
+
+            if (existing == null)
+            {
+                _context.EmailSettings.Add(settings);
+            }
+            else
+            {
+                settings.Id = existing.Id;
+                _context.Entry(existing).CurrentValues.SetValues(settings);
+            }
+
+            await _context.SaveChangesAsync();
+            return settings;
+        }
+
+        public async Task<string> DecryptPasswordAsync(string encryptedPassword)
+        {
+            return await Task.FromResult(_protector.Unprotect(encryptedPassword));
+        }
+
+        public async Task<bool> TestConnectionAsync(EmailSettings settings, string plainPassword)
+        {
+            try
+            {
+                using var client = new SmtpClient();
+                await client.ConnectAsync(settings.SmtpHost, settings.SmtpPort, settings.EnableSsl);
+                await client.AuthenticateAsync(settings.Username, plainPassword);
+                await client.DisconnectAsync(true);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "SMTP接続テストに失敗しました");
+                return false;
+            }
+        }
+    }
+}

--- a/Server/Services/IEmailService.cs
+++ b/Server/Services/IEmailService.cs
@@ -1,0 +1,9 @@
+namespace AutoDealerSphere.Server.Services
+{
+    public interface IEmailService
+    {
+        Task SendPasswordResetEmailAsync(string toEmail, string resetToken, string resetUrl);
+        Task SendEmailAsync(string toEmail, string subject, string htmlBody);
+        Task<bool> SendTestEmailAsync(string toEmail);
+    }
+}

--- a/Server/Services/IEmailSettingsService.cs
+++ b/Server/Services/IEmailSettingsService.cs
@@ -1,0 +1,12 @@
+using AutoDealerSphere.Shared.Models;
+
+namespace AutoDealerSphere.Server.Services
+{
+    public interface IEmailSettingsService
+    {
+        Task<EmailSettings?> GetSettingsAsync();
+        Task<EmailSettings> CreateOrUpdateSettingsAsync(EmailSettings settings, string plainPassword);
+        Task<string> DecryptPasswordAsync(string encryptedPassword);
+        Task<bool> TestConnectionAsync(EmailSettings settings, string plainPassword);
+    }
+}

--- a/Server/Services/SQLDBContext.cs
+++ b/Server/Services/SQLDBContext.cs
@@ -22,6 +22,8 @@ namespace AutoDealerSphere.Server.Services
 		public virtual DbSet<Invoice> Invoices { get; set; }
 		public virtual DbSet<InvoiceDetail> InvoiceDetails { get; set; }
 		public virtual DbSet<IssuerInfo> IssuerInfos { get; set; }
+		public virtual DbSet<EmailSettings> EmailSettings { get; set; }
+		public virtual DbSet<PasswordResetToken> PasswordResetTokens { get; set; }
 		protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
 		{
 			if (!optionsBuilder.IsConfigured)
@@ -124,6 +126,23 @@ namespace AutoDealerSphere.Server.Services
 			{
 				b.HasKey(e => e.Id);
 				b.Property(e => e.Id).UseIdentityColumn();
+			});
+
+			modelBuilder.Entity<EmailSettings>(b =>
+			{
+				b.HasKey(e => e.Id);
+				b.Property(e => e.Id).UseIdentityColumn();
+			});
+
+			modelBuilder.Entity<PasswordResetToken>(b =>
+			{
+				b.HasKey(e => e.Id);
+				b.Property(e => e.Id).UseIdentityColumn();
+
+				b.HasOne(p => p.User)
+					.WithMany()
+					.HasForeignKey(p => p.UserId)
+					.OnDelete(DeleteBehavior.Cascade);
 			});
 		}
 	}

--- a/Shared/Models/EmailSettings.cs
+++ b/Shared/Models/EmailSettings.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AutoDealerSphere.Shared.Models
+{
+    public class EmailSettings
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required(ErrorMessage = "SMTPホストを入力してください。")]
+        [StringLength(100, ErrorMessage = "SMTPホストは100文字までです。")]
+        public string SmtpHost { get; set; } = "";
+
+        [Required(ErrorMessage = "SMTPポートを入力してください。")]
+        [Range(1, 65535, ErrorMessage = "SMTPポートは1～65535の範囲で入力してください。")]
+        public int SmtpPort { get; set; } = 587;
+
+        public bool EnableSsl { get; set; } = true;
+
+        [Required(ErrorMessage = "送信者メールアドレスを入力してください。")]
+        [StringLength(100, ErrorMessage = "送信者メールアドレスは100文字までです。")]
+        [EmailAddress(ErrorMessage = "正しいメールアドレス形式で入力してください。")]
+        public string SenderEmail { get; set; } = "";
+
+        [Required(ErrorMessage = "送信者名を入力してください。")]
+        [StringLength(100, ErrorMessage = "送信者名は100文字までです。")]
+        public string SenderName { get; set; } = "";
+
+        [Required(ErrorMessage = "SMTP認証ユーザー名を入力してください。")]
+        [StringLength(100, ErrorMessage = "SMTP認証ユーザー名は100文字までです。")]
+        public string Username { get; set; } = "";
+
+        [Required(ErrorMessage = "SMTP認証パスワードを入力してください。")]
+        [StringLength(500, ErrorMessage = "SMTP認証パスワードは500文字までです。")]
+        public string EncryptedPassword { get; set; } = "";
+
+        public DateTime UpdatedAt { get; set; } = DateTime.Now;
+    }
+}

--- a/Shared/Models/PasswordResetToken.cs
+++ b/Shared/Models/PasswordResetToken.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AutoDealerSphere.Shared.Models
+{
+    public class PasswordResetToken
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        public int UserId { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string Token { get; set; } = "";
+
+        [Required]
+        public DateTime CreatedAt { get; set; } = DateTime.Now;
+
+        [Required]
+        public DateTime ExpiresAt { get; set; }
+
+        public bool IsUsed { get; set; } = false;
+
+        public User? User { get; set; }
+    }
+}


### PR DESCRIPTION
## 概要

Issue #116 の対応として、メール送信機能とパスワードリセット機能を実装しました。

## 主な変更内容

- MailKit/MimeKitパッケージを追加（v4.9.0）
- SMTP設定をデータベースに保存（暗号化対応）
- メール送信サービスの実装
- パスワードリセット機能の実装
- UI画面（メール設定、パスワード忘れ、リセット）を追加

## テスト計画

- [ ] メール設定画面でSMTP設定を登録
- [ ] 接続テストが成功することを確認
- [ ] テストメールが送信されることを確認
- [ ] パスワードリセットフローが正常に動作することを確認

Closes #116

🤖 Generated with [Claude Code](https://claude.ai/code)