### PR TITLE
メール設定UIを発行者情報管理画面に完全統合

### DIFF
--- a/Client/Pages/IssuerInfoPage.razor
+++ b/Client/Pages/IssuerInfoPage.razor
@@ -1,8 +1,6 @@
 @page "/issuerinfo"
 @using AutoDealerSphere.Client.Shared
 @using Syncfusion.Blazor.Navigations
-@using Syncfusion.Blazor.Inputs
-@using Syncfusion.Blazor.Buttons
 
 <SfBreadcrumb>
     <BreadcrumbItems>
@@ -13,66 +11,15 @@
 
 <h2>発行者情報管理</h2>
 
-<IssuerInfoForm Item="@issuerInfo" OnClickOK="SaveIssuerInfo" />
-
-<hr style="margin: 40px 0;" />
-
-<h3>メール設定</h3>
-
-@if (!string.IsNullOrEmpty(emailErrorMessage))
-{
-    <div class="alert alert-danger">@emailErrorMessage</div>
-}
-
-@if (!string.IsNullOrEmpty(emailSuccessMessage))
-{
-    <div class="alert alert-success">@emailSuccessMessage</div>
-}
-
-<div class="form-group">
-    <label>SMTPホスト</label>
-    <SfTextBox @bind-Value="@emailSettings.SmtpHost" Placeholder="例: smtp.gmail.com"></SfTextBox>
-</div>
-
-<div class="form-group">
-    <label>SMTPポート</label>
-    <SfNumericTextBox @bind-Value="@emailSettings.SmtpPort" Min="1" Max="65535" Format="n0"></SfNumericTextBox>
-</div>
-
-<div class="form-group">
-    <label>
-        <SfCheckBox @bind-Checked="@emailSettings.EnableSsl"></SfCheckBox>
-        SSL/TLS使用
-    </label>
-</div>
-
-<div class="form-group">
-    <label>送信者メールアドレス</label>
-    <SfTextBox @bind-Value="@emailSettings.SenderEmail" Placeholder="例: noreply@example.com"></SfTextBox>
-</div>
-
-<div class="form-group">
-    <label>送信者名</label>
-    <SfTextBox @bind-Value="@emailSettings.SenderName" Placeholder="例: AutoDealerSphere"></SfTextBox>
-</div>
-
-<div class="form-group">
-    <label>SMTP認証ユーザー名</label>
-    <SfTextBox @bind-Value="@emailSettings.Username" Placeholder="SMTP認証用のユーザー名"></SfTextBox>
-</div>
-
-<div class="form-group">
-    <label>SMTP認証パスワード</label>
-    <SfTextBox @bind-Value="@password" Type="InputType.Password" Placeholder="SMTP認証用のパスワード"></SfTextBox>
-</div>
-
-<div class="form-group">
-    <label>テストメール送信先</label>
-    <SfTextBox @bind-Value="@testEmailAddress" Placeholder="テストメールの送信先アドレス"></SfTextBox>
-</div>
-
-<div class="button-group">
-    <SfButton CssClass="e-primary" OnClick="SaveEmailSettings" Disabled="@isEmailProcessing">メール設定を保存</SfButton>
-    <SfButton CssClass="e-info" OnClick="TestConnection" Disabled="@isEmailProcessing">接続テスト</SfButton>
-    <SfButton CssClass="e-success" OnClick="SendTestEmail" Disabled="@isEmailProcessing">テストメール送信</SfButton>
-</div>
+<IssuerInfoForm
+    Item="@issuerInfo"
+    OnClickOK="SaveIssuerInfo"
+    EmailSettings="@emailSettings"
+    Password="@password"
+    TestEmailAddress="@testEmailAddress"
+    EmailErrorMessage="@emailErrorMessage"
+    EmailSuccessMessage="@emailSuccessMessage"
+    IsEmailProcessing="@isEmailProcessing"
+    OnSaveEmailSettings="SaveEmailSettings"
+    OnTestConnection="TestConnection"
+    OnSendTestEmail="SendTestEmail" />

--- a/Client/Pages/IssuerInfoPage.razor.cs
+++ b/Client/Pages/IssuerInfoPage.razor.cs
@@ -15,7 +15,7 @@ namespace AutoDealerSphere.Client.Pages
         private IssuerInfo issuerInfo = new IssuerInfo();
 
         // Email settings properties
-        private EmailSettingsModel emailSettings = new EmailSettingsModel();
+        private AutoDealerSphere.Shared.Models.EmailSettings emailSettings = new AutoDealerSphere.Shared.Models.EmailSettings();
         private string password = "";
         private string testEmailAddress = "";
         private string emailErrorMessage = "";
@@ -79,7 +79,7 @@ namespace AutoDealerSphere.Client.Pages
         {
             try
             {
-                var response = await Http.GetFromJsonAsync<EmailSettingsModel>("api/EmailSettings");
+                var response = await Http.GetFromJsonAsync<AutoDealerSphere.Shared.Models.EmailSettings>("api/EmailSettings");
                 if (response != null)
                 {
                     emailSettings = response;
@@ -228,23 +228,9 @@ namespace AutoDealerSphere.Client.Pages
         }
     }
 
-    // クライアント側のモデル（Shared/Modelsと同じ構造）
-    public class EmailSettingsModel
-    {
-        public int Id { get; set; }
-        public string SmtpHost { get; set; } = "";
-        public int SmtpPort { get; set; } = 587;
-        public bool EnableSsl { get; set; } = true;
-        public string SenderEmail { get; set; } = "";
-        public string SenderName { get; set; } = "";
-        public string Username { get; set; } = "";
-        public string EncryptedPassword { get; set; } = "";
-        public DateTime UpdatedAt { get; set; }
-    }
-
     public class EmailSettingsRequestModel
     {
-        public EmailSettingsModel Settings { get; set; } = new EmailSettingsModel();
+        public AutoDealerSphere.Shared.Models.EmailSettings Settings { get; set; } = new AutoDealerSphere.Shared.Models.EmailSettings();
         public string PlainPassword { get; set; } = "";
     }
 }

--- a/Client/Shared/IssuerInfoForm.razor
+++ b/Client/Shared/IssuerInfoForm.razor
@@ -132,4 +132,62 @@
 			</div>
 		</div>
 	</EditForm>
+
+	@if (EmailSettings != null)
+	{
+		<div class="form">
+			<h4>メール設定</h4>
+
+			@if (!string.IsNullOrEmpty(EmailErrorMessage))
+			{
+				<div class="alert alert-danger">@EmailErrorMessage</div>
+			}
+
+			@if (!string.IsNullOrEmpty(EmailSuccessMessage))
+			{
+				<div class="alert alert-success">@EmailSuccessMessage</div>
+			}
+
+			<div class="form-section">
+				<div class="form-row">
+					<label class="required">SMTPホスト</label>
+					<SfTextBox @bind-Value="@EmailSettings.SmtpHost" Placeholder="例: smtp.gmail.com"></SfTextBox>
+				</div>
+				<div class="form-row">
+					<label class="required">SMTPポート</label>
+					<SfNumericTextBox @bind-Value="@EmailSettings.SmtpPort" Min="1" Max="65535" Format="n0"></SfNumericTextBox>
+				</div>
+				<div class="form-row">
+					<label>SSL/TLS使用</label>
+					<SfCheckBox @bind-Checked="@EmailSettings.EnableSsl"></SfCheckBox>
+				</div>
+				<div class="form-row">
+					<label class="required">送信者メールアドレス</label>
+					<SfTextBox @bind-Value="@EmailSettings.SenderEmail" Placeholder="例: noreply@example.com"></SfTextBox>
+				</div>
+				<div class="form-row">
+					<label>送信者名</label>
+					<SfTextBox @bind-Value="@EmailSettings.SenderName" Placeholder="例: AutoDealerSphere"></SfTextBox>
+				</div>
+				<div class="form-row">
+					<label class="required">SMTP認証ユーザー名</label>
+					<SfTextBox @bind-Value="@EmailSettings.Username" Placeholder="SMTP認証用のユーザー名"></SfTextBox>
+				</div>
+				<div class="form-row">
+					<label class="required">SMTP認証パスワード</label>
+					<SfTextBox @bind-Value="@Password" Type="InputType.Password" Placeholder="SMTP認証用のパスワード"></SfTextBox>
+				</div>
+				<div class="form-row">
+					<label>テストメール送信先</label>
+					<SfTextBox @bind-Value="@TestEmailAddress" Placeholder="テストメールの送信先アドレス"></SfTextBox>
+				</div>
+			</div>
+
+			<div class="form-buttons">
+				<SfButton OnClick="OnSaveEmailSettings" IsPrimary="true" Disabled="@IsEmailProcessing">メール設定を保存</SfButton>
+				<SfButton OnClick="OnTestConnection" Disabled="@IsEmailProcessing">接続テスト</SfButton>
+				<SfButton OnClick="OnSendTestEmail" Disabled="@IsEmailProcessing">テストメール送信</SfButton>
+			</div>
+		</div>
+	}
 </div>

--- a/Client/Shared/IssuerInfoForm.razor.cs
+++ b/Client/Shared/IssuerInfoForm.razor.cs
@@ -10,7 +10,27 @@ namespace AutoDealerSphere.Client.Shared
         public IssuerInfo Item { get; set; } = new();
         [Parameter]
         public EventCallback<IssuerInfo> OnClickOK { get; set; }
-        
+
+        // Email settings parameters
+        [Parameter]
+        public AutoDealerSphere.Shared.Models.EmailSettings EmailSettings { get; set; }
+        [Parameter]
+        public string Password { get; set; }
+        [Parameter]
+        public string TestEmailAddress { get; set; }
+        [Parameter]
+        public string EmailErrorMessage { get; set; }
+        [Parameter]
+        public string EmailSuccessMessage { get; set; }
+        [Parameter]
+        public bool IsEmailProcessing { get; set; }
+        [Parameter]
+        public EventCallback OnSaveEmailSettings { get; set; }
+        [Parameter]
+        public EventCallback OnTestConnection { get; set; }
+        [Parameter]
+        public EventCallback OnSendTestEmail { get; set; }
+
         private bool _submitted = false;
 
         private class AccountType


### PR DESCRIPTION
## 概要

メール設定を発行者情報管理画面に完全に統合し、別の画面から持ってきたように見えないようにしました。

## 主な変更内容

- 区切り線（hr）を削除
- IssuerInfoFormコンポーネントにメール設定セクションを統合
- 発行者情報と同じデザインパターン（form-section, form-row）を使用
- EmailSettingsModelの重複定義を削除し、Shared.Models.EmailSettingsを使用

Related to #116

🤖 Generated with [Claude Code](https://claude.ai/code)