### PR TITLE
メール設定UIを発行者情報管理に完全統合

### DIFF
--- a/Client/Pages/IssuerInfoPage.razor
+++ b/Client/Pages/IssuerInfoPage.razor
@@ -16,10 +16,5 @@
     OnClickOK="SaveIssuerInfo"
     EmailSettings="@emailSettings"
     Password="@password"
-    TestEmailAddress="@testEmailAddress"
-    EmailErrorMessage="@emailErrorMessage"
-    EmailSuccessMessage="@emailSuccessMessage"
     IsEmailProcessing="@isEmailProcessing"
-    OnSaveEmailSettings="SaveEmailSettings"
-    OnTestConnection="TestConnection"
-    OnSendTestEmail="SendTestEmail" />
+    OnTestConnection="TestConnection" />

--- a/Client/Shared/IssuerInfoForm.razor
+++ b/Client/Shared/IssuerInfoForm.razor
@@ -68,8 +68,8 @@
 			</div>
 			<div class="form-row">
 				<label class="required">口座種別</label>
-				<SfDropDownList TValue="string" TItem="AccountType" 
-					@bind-Value="@Item.Bank1AccountType" 
+				<SfDropDownList TValue="string" TItem="AccountType"
+					@bind-Value="@Item.Bank1AccountType"
 					DataSource="@AccountTypes"
 					Placeholder="口座種別を選択"
 					AllowFiltering="false">
@@ -104,8 +104,8 @@
 			</div>
 			<div class="form-row">
 				<label>口座種別</label>
-				<SfDropDownList TValue="string" TItem="AccountType" 
-					@bind-Value="@Item.Bank2AccountType" 
+				<SfDropDownList TValue="string" TItem="AccountType"
+					@bind-Value="@Item.Bank2AccountType"
 					DataSource="@AccountTypes"
 					Placeholder="口座種別を選択"
 					AllowFiltering="false">
@@ -126,68 +126,50 @@
 			</div>
 			</div>
 
+			<h4>メール設定</h4>
+			<div class="form-section">
+			<div class="form-row">
+				<label>SMTPホスト</label>
+				<SfTextBox @bind-Value="@EmailSettings.SmtpHost" Placeholder="例: smtp.gmail.com"></SfTextBox>
+			</div>
+			<div class="form-row">
+				<label>SMTPポート</label>
+				<SfDropDownList TValue="int" TItem="SmtpPortOption"
+					@bind-Value="@EmailSettings.SmtpPort"
+					DataSource="@GetSmtpPortOptions()"
+					Placeholder="ポートを選択"
+					AllowFiltering="false">
+					<DropDownListFieldSettings Value="Value" Text="Text">
+					</DropDownListFieldSettings>
+				</SfDropDownList>
+			</div>
+			<div class="form-row">
+				<label>SSL/TLS使用</label>
+				<SfCheckBox Checked="@EmailSettings.EnableSsl" CheckedChanged="@((bool value) => OnSslChanged(value))"></SfCheckBox>
+			</div>
+			<div class="form-row">
+				<label>送信者メールアドレス</label>
+				<SfTextBox @bind-Value="@EmailSettings.SenderEmail" Placeholder="例: noreply@example.com"></SfTextBox>
+			</div>
+			<div class="form-row">
+				<label>送信者名</label>
+				<SfTextBox @bind-Value="@EmailSettings.SenderName" Placeholder="例: AutoDealerSphere"></SfTextBox>
+			</div>
+			<div class="form-row">
+				<label>SMTP認証ユーザー名</label>
+				<SfTextBox @bind-Value="@EmailSettings.Username" Placeholder="SMTP認証用のユーザー名"></SfTextBox>
+			</div>
+			<div class="form-row">
+				<label>SMTP認証パスワード</label>
+				<SfTextBox @bind-Value="@Password" Type="InputType.Password" Placeholder="SMTP認証用のパスワード"></SfTextBox>
+			</div>
+			</div>
+
 			<div class="form-buttons">
 				<SfButton OnClick="OnRegister" IsPrimary="true">保存</SfButton>
+				<SfButton OnClick="HandleTestConnection" Disabled="@IsEmailProcessing">接続テスト</SfButton>
 				<SfButton OnClick="OnCancel">キャンセル</SfButton>
 			</div>
 		</div>
 	</EditForm>
-
-	@if (EmailSettings != null)
-	{
-		<div class="form">
-			<h4>メール設定</h4>
-
-			@if (!string.IsNullOrEmpty(EmailErrorMessage))
-			{
-				<div class="alert alert-danger">@EmailErrorMessage</div>
-			}
-
-			@if (!string.IsNullOrEmpty(EmailSuccessMessage))
-			{
-				<div class="alert alert-success">@EmailSuccessMessage</div>
-			}
-
-			<div class="form-section">
-				<div class="form-row">
-					<label class="required">SMTPホスト</label>
-					<SfTextBox @bind-Value="@EmailSettings.SmtpHost" Placeholder="例: smtp.gmail.com"></SfTextBox>
-				</div>
-				<div class="form-row">
-					<label class="required">SMTPポート</label>
-					<SfNumericTextBox @bind-Value="@EmailSettings.SmtpPort" Min="1" Max="65535" Format="n0"></SfNumericTextBox>
-				</div>
-				<div class="form-row">
-					<label>SSL/TLS使用</label>
-					<SfCheckBox @bind-Checked="@EmailSettings.EnableSsl"></SfCheckBox>
-				</div>
-				<div class="form-row">
-					<label class="required">送信者メールアドレス</label>
-					<SfTextBox @bind-Value="@EmailSettings.SenderEmail" Placeholder="例: noreply@example.com"></SfTextBox>
-				</div>
-				<div class="form-row">
-					<label>送信者名</label>
-					<SfTextBox @bind-Value="@EmailSettings.SenderName" Placeholder="例: AutoDealerSphere"></SfTextBox>
-				</div>
-				<div class="form-row">
-					<label class="required">SMTP認証ユーザー名</label>
-					<SfTextBox @bind-Value="@EmailSettings.Username" Placeholder="SMTP認証用のユーザー名"></SfTextBox>
-				</div>
-				<div class="form-row">
-					<label class="required">SMTP認証パスワード</label>
-					<SfTextBox @bind-Value="@Password" Type="InputType.Password" Placeholder="SMTP認証用のパスワード"></SfTextBox>
-				</div>
-				<div class="form-row">
-					<label>テストメール送信先</label>
-					<SfTextBox @bind-Value="@TestEmailAddress" Placeholder="テストメールの送信先アドレス"></SfTextBox>
-				</div>
-			</div>
-
-			<div class="form-buttons">
-				<SfButton OnClick="OnSaveEmailSettings" IsPrimary="true" Disabled="@IsEmailProcessing">メール設定を保存</SfButton>
-				<SfButton OnClick="OnTestConnection" Disabled="@IsEmailProcessing">接続テスト</SfButton>
-				<SfButton OnClick="OnSendTestEmail" Disabled="@IsEmailProcessing">テストメール送信</SfButton>
-			</div>
-		</div>
-	}
 </div>


### PR DESCRIPTION
## 概要

メール設定を発行者情報管理画面に完全に統合し、単一の保存ボタンで全て保存できるようにしました。

## 主な変更内容

- 保存ボタンを統一（発行者情報とメール設定を一つのボタンで保存）
- 「メール設定を保存」ボタンを削除
- 「テストメール送信」ボタンと関連機能を削除
- SMTPポートを数値入力からドロップダウンに変更
- SSL/TLSチェックボックスに応じてポート選択肢を動的変更（465/587+または+25/587）
- メール設定セクションを発行者情報の一部として統合
- バリデーションを統一

Related+to+#116

🤖+Generated+with+[Claude+Code](https://claude.ai/code)) | [`claude/issue-116-20260212-1126`](https://github.com/k-amano/AutoDealerSphere/tree/claude/issue-116-20260212-1126